### PR TITLE
Add hex pattern option to organic sampler

### DIFF
--- a/tests/design_api/organic/test_sampler.py
+++ b/tests/design_api/organic/test_sampler.py
@@ -43,6 +43,16 @@ def test_sample_seed_points_with_density_field(bbox):
     mean_x = sum(pt[0] for pt in seeds) / len(seeds)
     assert mean_x > 0.5
 
+
+def test_sample_seed_points_hex_pattern(bbox):
+    min_corner, max_corner = bbox
+    seeds = sample_seed_points(10, min_corner, max_corner, min_dist=0.5, pattern="hex")
+    from design_api.services.voronoi_gen.honeycomb.seed import sample_seed_points as hc_sample
+
+    expected = hc_sample(min_corner, max_corner, cell_size=0.5, slice_thickness=0.5)
+    assert np.array(seeds).shape == expected.shape
+    assert np.allclose(np.array(seeds), expected)
+
 def test_sample_seed_points_anisotropic_constant_scale(bbox):
     min_corner, max_corner = bbox
     # Constant anisotropy scale factor of 2.0 along x-axis


### PR DESCRIPTION
## Summary
- allow `sample_seed_points` to generate hexagonal lattice via honeycomb generator
- add tests verifying deterministic hex pattern output

## Testing
- `pytest tests/design_api/organic/test_sampler.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_68a50dbd76f883269bdfa18a1e41aa86