### PR TITLE
Use bounding-box fallback for hexagon rays

### DIFF
--- a/tests/design_api/uniform/test_sampler.py
+++ b/tests/design_api/uniform/test_sampler.py
@@ -3,9 +3,11 @@ import pytest
 
 from design_api.services.voronoi_gen.uniform.sampler import compute_medial_axis, trace_hexagon
 
+
 class DummyMesh:
     def __init__(self, vertices):
         self.vertices = np.array(vertices)
+
 
 def test_compute_medial_axis_simple():
     # Simple tetrahedron vertices
@@ -22,20 +24,23 @@ def test_compute_medial_axis_simple():
     assert medial.ndim == 2 and medial.shape[1] == 3
     assert medial.shape[0] > 0
 
+
 def test_trace_hexagon_fallback():
     seed = np.array([0.0, 0.0, 0.0])
     # All medial points are behind the seed (negative x direction)
     medial = np.tile(np.array([-1.0, 0.0, 0.0]), (10, 1))
     plane_normal = np.array([0.0, 0.0, 1.0])
     hex_pts = trace_hexagon(seed, medial, plane_normal, max_distance=2.0)
-    # Should be a (6,3) array of points exactly 2 units from the seed
+    # Should be a (6,3) array of points not exceeding the expected radius
     assert isinstance(hex_pts, np.ndarray)
     assert hex_pts.shape == (6, 3)
     dists = np.linalg.norm(hex_pts - seed, axis=1)
-    # Distances should be non-negative and not exceed max_distance
     max_dist = 2.0
     assert np.all(dists >= 0)
     assert np.all(dists <= max_dist + 1e-6)
+    # At least one ray should hit the bounding box before reaching max_dist
+    assert np.any(dists < max_dist)
+
 
 def test_trace_hexagon_basic():
     seed = np.array([0.0, 0.0, 0.0])
@@ -50,3 +55,12 @@ def test_trace_hexagon_basic():
     # Should produce exactly 6 unique points
     unique_pts = {tuple(pt) for pt in hex_pts}
     assert len(unique_pts) == 6
+
+
+def test_trace_hexagon_no_intersection_error():
+    seed = np.array([0.0, 0.0, 0.0])
+    medial = np.tile(np.array([-1.0, 0.0, 0.0]), (10, 1))
+    plane_normal = np.array([0.0, 0.0, 1.0])
+    with pytest.raises(ValueError):
+        trace_hexagon(seed, medial, plane_normal)
+


### PR DESCRIPTION
## Summary
- compute ray fallback lengths by intersecting with the medial point bounding box
- raise an error when rays miss both medial points and fallback radius
- test hexagon tracing error conditions and bounding box behavior

## Testing
- `pytest tests/design_api/uniform/test_sampler.py`

------
https://chatgpt.com/codex/tasks/task_e_68a50dbb0aa483268a8e3f6146a46701