### PR TITLE
Allow regularize_hexagon to respect plane normal

### DIFF
--- a/design_api/services/voronoi_gen/uniform/sampler.py
+++ b/design_api/services/voronoi_gen/uniform/sampler.py
@@ -72,7 +72,7 @@ def trace_hexagon(seed_pt: np.ndarray, medial_points: np.ndarray, plane_normal: 
     # Attempt to regularize edge lengths if available
     try:
         from design_api.services.voronoi_gen.uniform.regularizer import regularize_hexagon
-        hex_pts = regularize_hexagon(hex_pts)
+        hex_pts = regularize_hexagon(hex_pts, plane_normal)
     except ImportError:
         pass
 

--- a/tests/design_api/uniform/test_regularizer.py
+++ b/tests/design_api/uniform/test_regularizer.py
@@ -25,7 +25,7 @@ def test_regularize_hexagon_preserves_centroid_and_edge_lengths():
     hex_pts = create_irregular_hexagon(radius=5.0, noise_level=1.0)
     centroid_before = np.mean(hex_pts, axis=0)
     # Regularize
-    new_pts = regularize_hexagon(hex_pts)
+    new_pts = regularize_hexagon(hex_pts, np.array([0.0, 0.0, 1.0]))
     centroid_after = np.mean(new_pts, axis=0)
     # Centroid should remain effectively unchanged
     assert np.allclose(centroid_before, centroid_after, atol=1e-6)


### PR DESCRIPTION
## Summary
- Orient hexagon regularization using a supplied plane normal and map back to 3‑D
- Update sampler and tests to use the new plane aware API

## Testing
- `pytest tests/design_api/uniform/test_regularizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50db7933883268aa83a72c4ae0449