### PR TITLE
test: add main coverage

### DIFF
--- a/tests/design_api/test_api.py
+++ b/tests/design_api/test_api.py
@@ -1,45 +1,90 @@
+import importlib
+import sys
+import types
+
 import pytest
-import fastapi
 from fastapi.testclient import TestClient
 
-from design_api.main import app
-from design_api.services import (
-    llm_service,
-    json_cleaner,
-    mapping as mapping_srv,
-    validator as validator_srv,
-)
 
-client = TestClient(app)
+@pytest.fixture()
+def client(monkeypatch):
+    """Return a TestClient with external deps stubbed out."""
+    fake_inference = types.SimpleNamespace(generate=lambda *a, **k: "{}")
+    monkeypatch.setitem(sys.modules, "ai_adapter.inference_pipeline", fake_inference)
 
-def test_design_happy(monkeypatch):
-    # stub out the entire service chain
-    monkeypatch.setattr(llm_service, 'generate_design_spec', lambda p: '{"shape":"sphere","size_mm":10}')
-    monkeypatch.setattr(json_cleaner, 'clean_llm_output', lambda raw: raw)
-    resp = client.post("/design", json={"prompt":"foo"})
+    fake_csg = types.SimpleNamespace(
+        review_request=lambda req: ([], "summary"),
+        generate_summary=lambda spec: "summary",
+        update_request=lambda sid, spec, raw: (spec, "summary"),
+    )
+    monkeypatch.setitem(sys.modules, "ai_adapter.csg_adapter", fake_csg)
+
+    fake_mapping = types.SimpleNamespace(
+        map_primitive=lambda spec: {
+            "root": {"primitive": {"sphere": {"radius": spec.get("size_mm", 0) / 2}}}
+        }
+    )
+    monkeypatch.setitem(sys.modules, "design_api.services.mapping", fake_mapping)
+
+    fake_validator = types.SimpleNamespace(validate_model_spec=lambda spec: spec)
+    monkeypatch.setitem(sys.modules, "design_api.services.validator", fake_validator)
+
+    app_module = importlib.import_module("design_api.main")
+    app_module.design_states.clear()
+    return TestClient(app_module.app)
+
+
+def test_design_happy(client, monkeypatch):
+    import design_api.main as main
+
+    monkeypatch.setattr(
+        main, "generate_design_spec", lambda p: '{"shape":"sphere","size_mm":10}'
+    )
+    monkeypatch.setattr(main, "clean_llm_output", lambda raw: raw)
+
+    resp = client.post("/design", json={"prompt": "foo"})
     assert resp.status_code == 200
     body = resp.json()
     assert body["root"]["primitive"]["sphere"]["radius"] == 5
 
-def test_design_bad_json(monkeypatch):
-    monkeypatch.setattr(llm_service, 'generate_design_spec', lambda p: 'not json')
-    monkeypatch.setattr(json_cleaner, 'clean_llm_output', lambda raw: raw)
-    resp = client.post("/design", json={"prompt":"foo"})
-    assert resp.status_code == 200
 
-def test_cors_headers():
+def test_design_bad_json(client, monkeypatch):
+    import design_api.main as main
+
+    monkeypatch.setattr(main, "generate_design_spec", lambda p: "not json")
+    monkeypatch.setattr(main, "clean_llm_output", lambda raw: raw)
+
+    resp = client.post("/design", json={"prompt": "foo"})
+    assert resp.status_code == 502
+
+
+def test_cors_headers(client):
     resp = client.options("/design")
-    # Accept either successful preflight or 405 Method Not Allowed
     if resp.status_code == 200:
-        # Ensure CORS headers exist
         assert "access-control-allow-origin" in resp.headers
         assert "access-control-allow-methods" in resp.headers
         assert "access-control-allow-headers" in resp.headers
     elif resp.status_code == 405:
-        # OPTIONS not supported but POST should be allowed
-        assert "allow" in resp.headers
-        allowed = resp.headers["allow"]
-        # allow header is comma-separated list of methods
+        allowed = resp.headers.get("allow", "")
         assert "POST" in [m.strip() for m in allowed.split(",")]
     else:
         pytest.fail(f"Unexpected status code {resp.status_code}")
+
+
+def test_review_update_submit_flow(client):
+    # Start with review to create a session
+    resp = client.post("/design/review", json={"raw": "spec"})
+    assert resp.status_code == 200
+    sid = resp.json()["sid"]
+
+    # Update the session
+    resp = client.post(
+        "/design/update",
+        json={"sid": sid, "raw": "more", "spec": []},
+    )
+    assert resp.status_code == 200
+
+    # Submit the design
+    resp = client.post(f"/design/submit?sid={sid}", json={})
+    assert resp.status_code == 200
+    assert resp.json()["sid"] == sid


### PR DESCRIPTION
## Summary
- stub external services to import `design_api.main`
- add tests covering `/design`, error handling, CORS, and review/update/submit flow

## Testing
- `pytest tests/design_api/test_api.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68a51afd36b88326a3e501b07cacd725