### PR TITLE
Clip Voronoi vertices within mesh bounds

### DIFF
--- a/tests/design_api/uniform/test_sampler.py
+++ b/tests/design_api/uniform/test_sampler.py
@@ -25,6 +25,25 @@ def test_compute_medial_axis_simple():
     assert medial.shape[0] > 0
 
 
+def test_compute_medial_axis_bounds_clipping():
+    vertices = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [100.0, 100.0, 100.0],
+    ]
+    mesh = DummyMesh(vertices)
+
+    # With default tolerance the Voronoi vertex lies outside the bounding box
+    medial_default = compute_medial_axis(mesh)
+    assert medial_default.shape == (0, 3)
+
+    # Expanding the bounds should retain the vertex
+    medial_tolerant = compute_medial_axis(mesh, tol=60.0)
+    assert medial_tolerant.shape[0] == 1
+    assert np.allclose(medial_tolerant[0], np.array([0.5, 0.5, 149.0]))
+
+
 def test_trace_hexagon_fallback():
     seed = np.array([0.0, 0.0, 0.0])
     # All medial points are behind the seed (negative x direction)


### PR DESCRIPTION
## Summary
- Filter Voronoi vertices to lie inside the mesh's bounding box and expose a tolerance parameter
- Add tests covering vertex clipping behavior

## Testing
- `pytest tests/design_api/uniform/test_sampler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a537eacb788326839311d366c1060a