### PR TITLE
Add Voronoi cell geometry option

### DIFF
--- a/design_api/services/voronoi_gen/voronoi_gen.py
+++ b/design_api/services/voronoi_gen/voronoi_gen.py
@@ -264,11 +264,22 @@ def build_hex_lattice(
     bbox_min: Tuple[float, float, float],
     bbox_max: Tuple[float, float, float],
     spacing: float,
-    primitive: Dict[str, Any]
-) -> Tuple[List[Tuple[float, float, float]], List[Tuple[int, int]]]:
+    primitive: Dict[str, Any],
+    *,
+    return_cells: bool = False,
+    **cell_kwargs: Any,
+) -> Union[
+    Tuple[List[Tuple[float, float, float]], List[Tuple[int, int]]],
+    Tuple[List[Tuple[float, float, float]], List[Tuple[int, int]], List[Dict[str, Any]]],
+]:
     """
     Generate a 3D hexagonally-packed lattice of points within the given AABB,
     and return both the list of points and the nearest-neighbor edges.
+
+    If ``return_cells`` is True, the function also constructs full Voronoi cell
+    geometry for each seed using :func:`construct_voronoi_cells` and returns the
+    resulting cell dictionaries as a third element.  Additional keyword
+    arguments are forwarded to ``construct_voronoi_cells`` (e.g. ``resolution``).
     """
     # Unpack bounds
     x0, y0, z0 = bbox_min
@@ -314,9 +325,61 @@ def build_hex_lattice(
     # Build adjacency efficiently via spatial pruning
     edges = prune_adjacency_via_grid(pts, spacing)
 
+    if return_cells:
+        from .organic.construct import construct_voronoi_cells
+        cells = construct_voronoi_cells(
+            pts, bbox_min, bbox_max, **cell_kwargs
+        )
+        return pts, edges, cells
+
     return pts, edges
 
 
 
-# Alias for Voronoi infill: direct seed adjacency via grid pruning
-compute_voronoi_adjacency = prune_adjacency_via_grid
+def compute_voronoi_adjacency(
+    points: List[Tuple[float, float, float]],
+    *args: Any,
+    spacing: Optional[float] = None,
+    **kwargs: Any,
+) -> Dict[int, List[int]]:
+    """
+    Compute adjacency of seed points using a spatial hash grid.
+
+    Parameters
+    ----------
+    points
+        Seed coordinates as ``(x, y, z)`` tuples.
+    spacing
+        Optional minimum spacing between seeds. If omitted, it is inferred
+        from the closest pair of points.
+    *args, **kwargs
+        Additional positional/keyword arguments are ignored, allowing this
+        function to be called with legacy signatures such as
+        ``(points, bbox_min, bbox_max, resolution)``.
+
+    Returns
+    -------
+    Dict[int, List[int]]
+        Mapping of seed index to a list of neighboring seed indices.
+    """
+    # Ignore legacy positional arguments (e.g., bbox, resolution)
+    if spacing is None or isinstance(spacing, (tuple, list)):
+        spacing = None
+
+    if spacing is None and points:
+        min_dist = float("inf")
+        for i, (x0, y0, z0) in enumerate(points):
+            for j in range(i + 1, len(points)):
+                x1, y1, z1 = points[j]
+                dx, dy, dz = x0 - x1, y0 - y1, z0 - z1
+                dist = math.sqrt(dx * dx + dy * dy + dz * dz)
+                if dist < min_dist:
+                    min_dist = dist
+        spacing = min_dist / 2.0 if min_dist < float("inf") else 0.0
+
+    edges = prune_adjacency_via_grid(points, spacing or 0.0)
+    adjacency: Dict[int, List[int]] = {i: [] for i in range(len(points))}
+    for i, j in edges:
+        adjacency[i].append(j)
+        adjacency[j].append(i)
+    return adjacency

--- a/tests/design_api/test_build_hex_lattice.py
+++ b/tests/design_api/test_build_hex_lattice.py
@@ -1,0 +1,21 @@
+from design_api.services.voronoi_gen.voronoi_gen import build_hex_lattice
+
+def test_build_hex_lattice_returns_cells():
+    bbox_min = (-1.0, -1.0, -1.0)
+    bbox_max = (1.0, 1.0, 1.0)
+    spacing = 0.5
+    primitive = {"sphere": {"radius": 1.0}}
+
+    pts, edges, cells = build_hex_lattice(
+        bbox_min,
+        bbox_max,
+        spacing,
+        primitive,
+        return_cells=True,
+        resolution=(8, 8, 8),
+    )
+
+    # Expect some points and an equal number of cell dictionaries
+    assert pts and len(cells) == len(pts)
+    # Each cell should include an SDF grid describing its geometry
+    assert all("sdf" in cell for cell in cells)


### PR DESCRIPTION
## Summary
- allow build_hex_lattice to optionally construct full Voronoi cell geometry via construct_voronoi_cells
- cover hex lattice cell generation with a new unit test
- fix circular import in voronoi_gen and add a spacing-aware compute_voronoi_adjacency wrapper

## Testing
- `pytest tests/design_api/test_build_hex_lattice.py::test_build_hex_lattice_returns_cells -q`

------
https://chatgpt.com/codex/tasks/task_e_68a65044b56c83268d6993d9ef422444