### PR TITLE
feat: expose voronoi cell edges

### DIFF
--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -74,8 +74,6 @@ function App() {
   const [edges, setEdges] = useState<number[][]>([]);
   const [infillPoints, setInfillPoints] = useState<[number, number, number][]>([]);
   const [infillEdges, setInfillEdges] = useState<number[][]>([]);
-  // Track infill cells
-  const [infillCells, setInfillCells] = useState<any[]>([]);
   // Debug: log infillPoints and infillEdges state updates
   useEffect(() => {
     console.log('[UI] infillPoints state updated:', infillPoints);
@@ -198,17 +196,16 @@ function App() {
       }
       // Handle updated spec with nested modifiers
       if (data.spec && Array.isArray(data.spec)) {
+        const infill = data.spec[0]?.modifiers?.infill;
+        console.log('[UI] backend infill counts:', {
+          points: infill?.seed_points?.length,
+          edges: infill?.edges?.length,
+          sampleEdges: infill?.edges?.slice(0, 5),
+        });
         setSpec(data.spec);
-        setEdges(data.spec[0]?.modifiers?.infill?.edges ?? []);
-        setInfillPoints(data.spec[0]?.modifiers?.infill?.cells?.points ?? []);
-        setInfillEdges(data.spec[0]?.modifiers?.infill?.cells?.edges ?? []);
-        // NEW: extract and store all infill cell objects
-        const cells = data.spec.flatMap(node => node.modifiers?.infill?.cells || []);
-        console.debug("Loaded infill cells:", cells.length, cells.slice(0,2));
-        setInfillCells(cells);
-        console.log('[UI] backend infill.cells:', data.spec[0]?.modifiers?.infill?.cells);
-        console.log('[UI] incoming infillPoints:', data.spec[0]?.modifiers?.infill?.cells?.points);
-        console.log('[UI] incoming infillEdges:', data.spec[0]?.modifiers?.infill?.cells?.edges);
+        setEdges(infill?.edges ?? []);
+        setInfillPoints(infill?.seed_points ?? []);
+        setInfillEdges(infill?.edges ?? []);
         setSpecText(JSON.stringify(reorderSpec(data.spec), null, 2));
         if (data.summary) {
           setSummary(data.summary);
@@ -559,7 +556,6 @@ function App() {
                   edges={edges}
                   infillPoints={infillPoints}
                   infillEdges={infillEdges}
-                  cells={infillCells}           // NEW
                   bbox={[0, 0, 0, 1, 1, 1]}
                   thickness={0.35}
                   maxSteps={256}
@@ -579,7 +575,6 @@ function App() {
                   edges={edges}
                   infillPoints={infillPoints}
                   infillEdges={infillEdges}
-                  cells={infillCells}           // NEW
                   bbox={[0, 0, 0, 1, 1, 1]}
                   thickness={0.35}
                   maxSteps={256}

--- a/implicitus-ui/src/components/VoronoiCanvas.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.tsx
@@ -118,8 +118,8 @@ interface VoronoiCanvasProps {
   strutColor?: string | number;
   infillPoints?: [number, number, number][];
   infillEdges?: [number, number][];
-  /** Infill cells */
-  cells: Array<{ verts: number[][]; faces: number[][] }>;
+  /** Optional full cell geometry */
+  cells?: Array<{ verts: number[][]; faces: number[][] }>;
 }
 
 // Toggle verbose logging
@@ -156,6 +156,9 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
   const safeInfillEdges = Array.isArray(infillEdges)
     ? infillEdges
     : (typeof infillEdges === 'string' ? JSON.parse(infillEdges) : []);
+  const safeCells = Array.isArray(cells)
+    ? cells
+    : (typeof cells === 'string' ? JSON.parse(cells) : []);
   // Ensure only well-formed point and edge arrays
   const validSeedPoints = Array.isArray(safeSeedPoints)
     ? safeSeedPoints.filter(p => Array.isArray(p) && p.length === 3 && p.every(coord => typeof coord === 'number'))
@@ -169,8 +172,12 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
   const validInfillEdges = Array.isArray(safeInfillEdges)
     ? safeInfillEdges.filter(e => Array.isArray(e) && e.length === 2 && e.every(idx => Number.isInteger(idx)))
     : [];
+  const validCells = Array.isArray(safeCells)
+    ? safeCells.filter(c => Array.isArray(c?.verts) && Array.isArray(c?.faces))
+    : [];
   DEBUG_CANVAS && console.log('VoronoiCanvas validInfillPoints count:', validInfillPoints.length);
   DEBUG_CANVAS && console.log('VoronoiCanvas validInfillEdges count:', validInfillEdges.length);
+  DEBUG_CANVAS && console.log('VoronoiCanvas validCells count:', validCells.length);
   DEBUG_CANVAS && console.log('VoronoiCanvas sample validInfillPoints (first 5):', validInfillPoints.slice(0,5));
   DEBUG_CANVAS && console.log('VoronoiCanvas sample validInfillEdges (first 5):', validInfillEdges.slice(0,5));
   DEBUG_CANVAS && console.log('VoronoiCanvas safe data:', { safeSeedPoints, safeEdges });
@@ -194,6 +201,7 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
     return validEdges.filter((_, idx) => lengths[idx] <= threshold);
   }, [validEdges, validSeedPoints]);
   DEBUG_CANVAS && console.log('VoronoiCanvas filteredEdges count:', filteredEdges.length);
+  DEBUG_CANVAS && console.log('VoronoiCanvas sample filteredEdges (first 5):', filteredEdges.slice(0,5));
   // For debug: only render seed points inside the sphere when no edges
   const debugSeedPoints = useMemo(() => {
     if (filteredEdges.length > 0) return [];
@@ -254,7 +262,7 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
 
   // Merge all cell geometries into a single mesh
   const mergedCellGeometry = useMemo(() => {
-    if (cells.length === 0) return null;
+    if (validCells.length === 0) return null;
     // filter cells to only those inside the seed-points bounding sphere
     const xs = validSeedPoints.map(p => p[0]);
     const ys = validSeedPoints.map(p => p[1]);
@@ -267,7 +275,8 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
     const sphereCz = (minZ + maxZ) / 2;
     const sphereR  = Math.max(maxX - minX, maxY - minY, maxZ - minZ) / 2;
 
-    const filteredCells = cells.filter(cell => {
+    const filteredCells = validCells.filter(cell => {
+      if (!Array.isArray(cell.verts) || cell.verts.length === 0) return false;
       // compute centroid of this cell
       const centroid = cell.verts.reduce(
         (acc, [x, y, z]) => [acc[0] + x, acc[1] + y, acc[2] + z],
@@ -306,7 +315,7 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
     geom.setIndex(indices);
     geom.computeVertexNormals();
     return geom;
-  }, [cells, validSeedPoints]);
+  }, [validCells, validSeedPoints]);
 
   return (
     <div style={{


### PR DESCRIPTION
## Summary
- plumb Voronoi seed edges directly into the viewer
- tolerate missing cell geometry in VoronoiCanvas
- compute Voronoi adjacency using provided spacing or min_dist and add debug logs
- surface backend infill counts and filtered edge samples in the UI for easier troubleshooting

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest -k test_build_hex_lattice_returns_cells tests/design_api/test_build_hex_lattice.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6669177208326ae057d87b74156e7