### PR TITLE
Avoid duplicate infill strut rendering

### DIFF
--- a/implicitus-ui/src/components/VoronoiCanvas.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.tsx
@@ -381,7 +381,7 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
             color={strutColor}
           />
         )}
-        {showInfill && validInfillEdges.length > 0 && (
+        {showInfill && !showStruts && validInfillEdges.length > 0 && (
           <lineSegments>
             <bufferGeometry attach="geometry">
               <bufferAttribute


### PR DESCRIPTION
## Summary
- Prevent double strut rendering by skipping infill lineSegments when strut view is active.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a68154b0208326904f1a5e8600c54f