### PR TITLE
Ensure lattice updates after JSON edits

### DIFF
--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -331,7 +331,11 @@ function App() {
       if (data.spec && Array.isArray(data.spec)) {
         setSpec(data.spec);
         setEdges(data.spec[0]?.modifiers?.infill?.edges ?? []);
+        // also refresh infill seed points and edges so the viewer reflects updates
+        setInfillPoints(data.spec[0]?.modifiers?.infill?.seed_points ?? []);
+        setInfillEdges(data.spec[0]?.modifiers?.infill?.edges ?? []);
         setSpecText(JSON.stringify(reorderSpec(data.spec), null, 2));
+        setIsDirty(false);
         if (data.summary) {
           setSummary(data.summary);
           setMessages(prev => [...prev, { speaker: 'assistant', text: data.summary }]);


### PR DESCRIPTION
## Summary
- Refresh infill seed points and edges when applying JSON changes so lattice view updates accordingly
- Mark spec as clean after applying updates

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in existing code)*
- `npm run build` *(fails: missing module type declarations and JSX types)*

------
https://chatgpt.com/codex/tasks/task_e_68a68522fcdc8326afbab629248ff99c