### PR TITLE
Generate Voronoi lattice edges

### DIFF
--- a/design_api/services/voronoi_gen/organic/construct.py
+++ b/design_api/services/voronoi_gen/organic/construct.py
@@ -15,6 +15,12 @@ def _voronoi_helpers():
 
     return vg
 
+
+def compute_voronoi_adjacency(*args, **kwargs):
+    """Proxy to :mod:`voronoi_gen.compute_voronoi_adjacency` for monkeypatching."""
+    vg = _voronoi_helpers()
+    return vg.compute_voronoi_adjacency(*args, **kwargs)
+
 def construct_voronoi_cells(
     points: List[Tuple[float, float, float]],
     bbox_min: Tuple[float, float, float],
@@ -220,7 +226,14 @@ def construct_voronoi_cells(
         })
 
     # Attach neighbor lists by index
-    adjacency = compute_voronoi_adjacency(points, bbox_min, bbox_max, resolution)
+    adjacency_raw = compute_voronoi_adjacency(points, bbox_min, bbox_max, resolution)
+    if isinstance(adjacency_raw, list):
+        adjacency = {i: [] for i in range(len(points))}
+        for i, j in adjacency_raw:
+            adjacency[i].append(j)
+            adjacency[j].append(i)
+    else:
+        adjacency = adjacency_raw
     for idx, cell in enumerate(cells):
         cell["neighbors"] = adjacency.get(idx, [])
 
@@ -331,9 +344,16 @@ def construct_surface_voronoi_cells(
                 "neighbors": []
             })
         # Compute adjacency via compute_voronoi_adjacency
-        adjacency = compute_voronoi_adjacency(
+        adjacency_raw = compute_voronoi_adjacency(
             seed_points, bbox_min, bbox_max, resolution
         )
+        if isinstance(adjacency_raw, list):
+            adjacency = {i: [] for i in range(len(seed_points))}
+            for i, j in adjacency_raw:
+                adjacency[i].append(j)
+                adjacency[j].append(i)
+        else:
+            adjacency = adjacency_raw
         for idx, cell in enumerate(cells):
             cell["neighbors"] = adjacency.get(idx, [])
         return cells
@@ -403,9 +423,16 @@ def construct_surface_voronoi_cells(
             "area": 0.0
         })
     # Compute adjacency and add to each cell dict
-    adjacency = compute_voronoi_adjacency(
+    adjacency_raw = compute_voronoi_adjacency(
         seed_points, bbox_min, bbox_max, resolution
     )
+    if isinstance(adjacency_raw, list):
+        adjacency = {i: [] for i in range(len(seed_points))}
+        for i, j in adjacency_raw:
+            adjacency[i].append(j)
+            adjacency[j].append(i)
+    else:
+        adjacency = adjacency_raw
     for idx, cell in enumerate(cells):
         cell["neighbors"] = adjacency.get(idx, [])
     return cells

--- a/tests/design_api/test_build_hex_lattice.py
+++ b/tests/design_api/test_build_hex_lattice.py
@@ -15,7 +15,7 @@ def test_build_hex_lattice_returns_cells():
         resolution=(8, 8, 8),
     )
 
-    # Expect some points and an equal number of cell dictionaries
-    assert pts and len(cells) == len(pts)
-    # Each cell should include an SDF grid describing its geometry
-    assert all("sdf" in cell for cell in cells)
+    # Expect some Voronoi vertices and connecting edges
+    assert pts and edges
+    # Returned cells should contain SDF grids describing each seed cell
+    assert cells and all("sdf" in cell for cell in cells)


### PR DESCRIPTION
## Summary
- Build Voronoi diagram of seed points to derive lattice vertices and ridge-based edges with a SciPy fallback to simple adjacency
- Allow organic Voronoi constructors to proxy `compute_voronoi_adjacency` and convert edge lists into neighbor maps
- Simplify hex lattice test expectations for new vertex/edge output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68b6aa5f48326bd5f81675625d2ae