### PR TITLE
Add adaptive Voronoi adjacency fallback with tests

### DIFF
--- a/tests/design_api/organic/test_adaptive_neighbors.py
+++ b/tests/design_api/organic/test_adaptive_neighbors.py
@@ -1,0 +1,35 @@
+import pytest
+from design_api.services.voronoi_gen.organic.adaptive import OctreeNode
+from design_api.services.voronoi_gen.organic import construct as construct_module
+from design_api.services.voronoi_gen.organic.construct import construct_voronoi_cells
+
+
+def test_construct_voronoi_cells_adaptive_fallback_neighbors(monkeypatch):
+    # Simulate missing SciPy so Delaunay is None
+    monkeypatch.setattr(construct_module, "Delaunay", None)
+    seeds = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+    bbox_min = (0.0, 0.0, 0.0)
+    bbox_max = (1.0, 1.0, 1.0)
+    root = OctreeNode(bbox_min, bbox_max)
+    cells = construct_voronoi_cells(seeds, bbox_min, bbox_max, adaptive_grid=root)
+    assert len(cells) == 2
+    for cell in cells:
+        expected = {s for s in seeds if s != cell["site"]}
+        assert set(cell["neighbors"]) == expected
+
+
+def test_construct_voronoi_cells_adaptive_delaunay_neighbors():
+    pytest.importorskip("scipy.spatial")
+    seeds = [
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+    ]
+    bbox_min = (0.0, 0.0, 0.0)
+    bbox_max = (1.0, 1.0, 1.0)
+    root = OctreeNode(bbox_min, bbox_max)
+    cells = construct_voronoi_cells(seeds, bbox_min, bbox_max, adaptive_grid=root)
+    for cell in cells:
+        expected = {s for s in seeds if s != cell["site"]}
+        assert set(cell["neighbors"]) == expected


### PR DESCRIPTION
## Summary
- handle missing SciPy Delaunay in `construct_voronoi_cells` by falling back to `compute_voronoi_adjacency`
- populate Voronoi cell neighbors in fallback path
- add unit tests verifying both Delaunay and fallback adjacency

## Testing
- `pytest tests/design_api/organic/test_adaptive_neighbors.py::test_construct_voronoi_cells_adaptive_fallback_neighbors -q`
- `pytest tests/design_api/organic/test_adaptive_neighbors.py::test_construct_voronoi_cells_adaptive_delaunay_neighbors -q`
- `pytest tests/design_api/organic/test_construct.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a15a167083269a4e9c8767d7c503