### PR TITLE
fix: skip voronoi cell generation during infill

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -25,7 +25,6 @@ from design_api.services.validator import validate_model_spec as validate_proto
 from ai_adapter.csg_adapter import review_request, generate_summary, update_request
 from design_api.services.voronoi_gen.voronoi_gen import (
     compute_voronoi_adjacency,
-    construct_voronoi_cells,
 )
 
 @dataclass
@@ -155,15 +154,6 @@ async def review(req: dict, sid: Optional[str] = None):
 
                     inf["edges"] = edge_list
 
-                    try:
-                        cells = construct_voronoi_cells(
-                            pts, bbox_min, bbox_max, return_cells=True
-                        )
-                    except TypeError:
-                        # Fallback for older signature without return_cells
-                        cells = construct_voronoi_cells(pts, bbox_min, bbox_max)
-                    inf["cells"] = cells
-
                     logging.debug(
                         f"[DEBUG review] spacing={spacing} produced {len(edge_list)} edges; sample: {edge_list[:10]}"
                     )
@@ -253,13 +243,6 @@ async def update(req: UpdateRequest):
                         edge_list.append([i, j])
 
                 inf["edges"] = edge_list
-                try:
-                    cells = construct_voronoi_cells(
-                        pts, bbox_min, bbox_max, return_cells=True
-                    )
-                except TypeError:
-                    cells = construct_voronoi_cells(pts, bbox_min, bbox_max)
-                inf["cells"] = cells
 
                 logging.debug(
                     f"[DEBUG update] spacing={spacing} produced {len(edge_list)} edges; sample: {edge_list[:10]}"

--- a/implicitus-ui/src/components/VoronoiMesh.tsx
+++ b/implicitus-ui/src/components/VoronoiMesh.tsx
@@ -28,6 +28,12 @@ const VoronoiMesh: React.FC<VoronoiMeshProps> = ({
   sphereCenter,
   sphereRadius
 }) => {
+  // If there are no seed points, there is nothing to render.
+  // Returning early avoids creating geometries with infinite or NaN
+  // dimensions which would stall the renderer and hide the grid.
+  if (!seedPoints || seedPoints.length === 0) {
+    return null;
+  }
   // Derive world-space bounding box from seedPoints
   const xs = seedPoints.map(p => p[0]);
   const ys = seedPoints.map(p => p[1]);


### PR DESCRIPTION
## Summary
- avoid constructing heavy Voronoi cell SDFs in review/update endpoints to keep API responsive
- keep Voronoi edge generation for infill visualization

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7ad4ef6a883269f04d57fa9390ce7