### PR TITLE
fix: skip voronoi cell generation during infill

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -14,6 +14,14 @@ MAX_SEED_POINTS = 7500
 import random
 import numpy as np
 
+def _parse_bool(value):
+    """Robustly interpret a JSON boolean that may arrive as a string."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
 def _auto_generate_seed_points(
     shape: str,
     params: dict,
@@ -430,7 +438,7 @@ def interpret_llm_request(llm_output):
                 shape, params = next(iter(node['primitive'].items()))
                 if 'seed_points' not in infill:
                     # include uniform/resolution flags in update branch
-                    uniform = bool(infill.get('uniform', False))
+                    uniform = _parse_bool(infill.get('uniform', False))
                     resolution = tuple(infill.get('resolution', [32, 32, 32]))
                     logging.debug(f"interpret_llm_request update-branch: uniform sampling={uniform}, resolution={resolution}")
                     seeds = _auto_generate_seed_points(
@@ -509,7 +517,7 @@ def interpret_llm_request(llm_output):
             if 'seed_points' not in infill:
                 shape, params = next(iter(node['primitive'].items()))
                 # include uniform/resolution flags in update branch
-                uniform = bool(infill.get('uniform', False))
+                uniform = _parse_bool(infill.get('uniform', False))
                 resolution = tuple(infill.get('resolution', [32, 32, 32]))
                 logging.debug(f"interpret_llm_request update-branch: uniform sampling={uniform}, resolution={resolution}")
                 seeds = _auto_generate_seed_points(
@@ -743,7 +751,7 @@ def update_request(sid: str, spec: list, raw: str):
             infill.setdefault('shell_offset', 0.0)
             infill.setdefault('auto_cap', False)
             # always regenerate seed points, and expose num_points parameter
-            uniform = bool(infill.get('uniform', False))
+            uniform = _parse_bool(infill.get('uniform', False))
             resolution = tuple(infill.get('resolution', [32, 32, 32]))
             seeds = _auto_generate_seed_points(
                 shape, params, bbox_min, bbox_max,

--- a/design_api/main.py
+++ b/design_api/main.py
@@ -25,7 +25,6 @@ from design_api.services.validator import validate_model_spec as validate_proto
 from ai_adapter.csg_adapter import review_request, generate_summary, update_request
 from design_api.services.voronoi_gen.voronoi_gen import (
     compute_voronoi_adjacency,
-    construct_voronoi_cells,
 )
 
 @dataclass
@@ -155,15 +154,6 @@ async def review(req: dict, sid: Optional[str] = None):
 
                     inf["edges"] = edge_list
 
-                    try:
-                        cells = construct_voronoi_cells(
-                            pts, bbox_min, bbox_max, return_cells=True
-                        )
-                    except TypeError:
-                        # Fallback for older signature without return_cells
-                        cells = construct_voronoi_cells(pts, bbox_min, bbox_max)
-                    inf["cells"] = cells
-
                     logging.debug(
                         f"[DEBUG review] spacing={spacing} produced {len(edge_list)} edges; sample: {edge_list[:10]}"
                     )
@@ -253,13 +243,6 @@ async def update(req: UpdateRequest):
                         edge_list.append([i, j])
 
                 inf["edges"] = edge_list
-                try:
-                    cells = construct_voronoi_cells(
-                        pts, bbox_min, bbox_max, return_cells=True
-                    )
-                except TypeError:
-                    cells = construct_voronoi_cells(pts, bbox_min, bbox_max)
-                inf["cells"] = cells
 
                 logging.debug(
                     f"[DEBUG update] spacing={spacing} produced {len(edge_list)} edges; sample: {edge_list[:10]}"

--- a/implicitus-ui/src/components/VoronoiMesh.tsx
+++ b/implicitus-ui/src/components/VoronoiMesh.tsx
@@ -28,6 +28,12 @@ const VoronoiMesh: React.FC<VoronoiMeshProps> = ({
   sphereCenter,
   sphereRadius
 }) => {
+  // If there are no seed points, there is nothing to render.
+  // Returning early avoids creating geometries with infinite or NaN
+  // dimensions which would stall the renderer and hide the grid.
+  if (!seedPoints || seedPoints.length === 0) {
+    return null;
+  }
   // Derive world-space bounding box from seedPoints
   const xs = seedPoints.map(p => p[0]);
   const ys = seedPoints.map(p => p[1]);

--- a/tests/ai_adapter/test_csg_adapter.py
+++ b/tests/ai_adapter/test_csg_adapter.py
@@ -130,6 +130,25 @@ def test_review_request_with_dict_input_multiple_primitives():
     assert "box" in summary.lower()
 
 
+def test_uniform_string_false_parsing(monkeypatch):
+    called = {}
+
+    def fake_auto(shape, params, bbox_min, bbox_max, spacing, *, uniform=False, grid_resolution=(32, 32, 32)):
+        called['uniform'] = uniform
+        return []
+
+    import ai_adapter.csg_adapter as csg
+    monkeypatch.setattr(csg, '_auto_generate_seed_points', fake_auto)
+
+    request_data = {
+        'shape': 'sphere',
+        'size_mm': 10,
+        'infill': {'pattern': 'voronoi', 'uniform': 'false'}
+    }
+    csg.interpret_llm_request(request_data)
+    assert called['uniform'] is False
+
+
 # Additional tests for review_request with existing/modified spec
 def test_review_request_with_existing_spec():
     # Simulate UI sending back the spec without parsing again


### PR DESCRIPTION
## Summary
- avoid constructing heavy Voronoi cell SDFs in review/update endpoints to keep API responsive
- keep Voronoi edge generation for infill visualization
- handle string `uniform` flags so Poisson sampling remains hexagonal

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7ad4ef6a883269f04d57fa9390ce7