### PR TITLE
Use Matrix4.compose for Voronoi strut transforms

### DIFF
--- a/implicitus-ui/src/components/VoronoiStruts.tsx
+++ b/implicitus-ui/src/components/VoronoiStruts.tsx
@@ -43,10 +43,12 @@ export const VoronoiStruts: React.FC<VoronoiStrutsProps> = ({
         dir.normalize()
       );
       // build matrix
-      const mat = new THREE.Matrix4()
-        .makeRotationFromQuaternion(quat)
-        .setPosition(mid)
-        .scale(new THREE.Vector3(strutRadius, len * 0.5, strutRadius));
+      const mat = new THREE.Matrix4();
+      mat.compose(
+        mid,
+        quat,
+        new THREE.Vector3(strutRadius, len, strutRadius)
+      );
       mesh.setMatrixAt(i, mat);
     });
     mesh.instanceMatrix.needsUpdate = true;


### PR DESCRIPTION
## Summary
- Compose transforms for Voronoi struts using `Matrix4.compose`
- Avoid scaling translation and apply full strut length

## Testing
- `npm --prefix implicitus-ui test` *(fails: sh: 1: vitest: not found)*
- `npm --prefix implicitus-ui run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b8dae9588326a259b5436590b4ca