### PR TITLE
Improve robustness of hexagon construction

### DIFF
--- a/design_api/services/voronoi_gen/uniform/sampler.py
+++ b/design_api/services/voronoi_gen/uniform/sampler.py
@@ -152,32 +152,89 @@ def trace_hexagon(
         neighbor_2d_all = np.column_stack((vecs.dot(u), vecs.dot(v)))
         angles = np.mod(np.arctan2(neighbor_2d_all[:, 1], neighbor_2d_all[:, 0]), 2 * np.pi)
 
+        # Preselect nearest neighbors in six angular bins but retain
+        # additional candidates for potential fallback.
         sel_2d: List[np.ndarray] = []
         used = np.zeros(len(angles), dtype=bool)
+        candidate_lists: List[List[int]] = []
         for k in range(6):
             target = 2 * np.pi * k / 6
             diffs = np.abs(np.angle(np.exp(1j * (angles - target))))
-            diffs[used] = np.inf
-            idx = int(np.argmin(diffs))
-            used[idx] = True
+            order = np.argsort(diffs)
+            idx = None
+            for cand in order:
+                if not used[cand]:
+                    idx = cand
+                    used[cand] = True
+                    break
+            if idx is None:
+                return None
             sel_2d.append(neighbor_2d_all[idx])
+            # store remaining unused candidates for this bin
+            remaining = [c for c in order if not used[c]]
+            candidate_lists.append(remaining)
 
+        # Sort neighbors counter-clockwise and reorder candidate lists
         neighbor_2d = np.vstack(sel_2d)
         ang = np.arctan2(neighbor_2d[:, 1], neighbor_2d[:, 0])
         order = np.argsort(ang)
         neighbor_2d = neighbor_2d[order]
+        candidate_lists = [candidate_lists[i] for i in order]
 
         normals = neighbor_2d
         bs = np.sum(neighbor_2d ** 2, axis=1) / 2.0
         verts_2d: List[np.ndarray] = []
+        det_tol = 1e-8
         for i in range(6):
             j = (i + 1) % 6
             N = np.vstack([normals[i], normals[j]])
             B = np.array([bs[i], bs[j]])
+            det = float(np.linalg.det(N))
+
+            # Attempt to swap in alternative neighbors if matrix is nearly singular
+            if abs(det) < det_tol:
+                replaced = False
+                for alt in candidate_lists[j]:
+                    if used[alt]:
+                        continue
+                    cand = neighbor_2d_all[alt]
+                    det_alt = float(np.linalg.det(np.vstack([normals[i], cand])))
+                    if abs(det_alt) >= det_tol:
+                        logging.debug("trace_hexagon: replaced neighbor %d with alternative to avoid singular matrix", j)
+                        normals[j] = cand
+                        bs[j] = np.sum(cand ** 2) / 2.0
+                        used[alt] = True
+                        candidate_lists[j] = [c for c in candidate_lists[j] if c != alt]
+                        det = det_alt
+                        replaced = True
+                        break
+                if not replaced:
+                    for alt in candidate_lists[i]:
+                        if used[alt]:
+                            continue
+                        cand = neighbor_2d_all[alt]
+                        det_alt = float(np.linalg.det(np.vstack([cand, normals[j]])))
+                        if abs(det_alt) >= det_tol:
+                            logging.debug("trace_hexagon: replaced neighbor %d with alternative to avoid singular matrix", i)
+                            normals[i] = cand
+                            bs[i] = np.sum(cand ** 2) / 2.0
+                            used[alt] = True
+                            candidate_lists[i] = [c for c in candidate_lists[i] if c != alt]
+                            det = det_alt
+                            replaced = True
+                            break
+                if not replaced:
+                    logging.debug("trace_hexagon: degenerate neighbor pair (%d,%d); resampling", i, j)
+                    return None
+
             try:
                 x = np.linalg.solve(N, B)
             except np.linalg.LinAlgError:
-                return None
+                logging.debug("trace_hexagon: using least-squares fallback for singular matrix")
+                try:
+                    x, *_ = np.linalg.lstsq(N, B, rcond=None)
+                except Exception:
+                    x = np.linalg.pinv(N) @ B
             verts_2d.append(x)
 
         if len(verts_2d) != 6:


### PR DESCRIPTION
## Summary
- handle degenerate neighbor normals by checking determinants before solving
- fall back to alternate neighbors or log and resample when matrices are singular
- use least-squares as final fallback and emit debug logs for these cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e63ece7083268953868d72fa021a