### PR TITLE
test: add coverage for construct_from_vecs deduplication

### DIFF
--- a/tests/design_api/uniform/test_sampler.py
+++ b/tests/design_api/uniform/test_sampler.py
@@ -164,3 +164,39 @@ def test_trace_hexagon_origin_medial_cluster(monkeypatch):
     # Fallback rays yield a highly irregular hexagon
     assert np.ptp(edges) > 0.3
 
+
+def test_construct_from_vecs_handles_duplicates_and_collinear():
+    sampler = pytest.importorskip("design_api.services.voronoi_gen.uniform.sampler")
+    _construct_from_vecs = getattr(sampler, "_construct_from_vecs", None)
+    if _construct_from_vecs is None:
+        pytest.skip("_construct_from_vecs not available")
+
+    seed = np.zeros(3)
+    medial = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],  # duplicate
+            [0.999999, 0.001, 0.0],  # nearly collinear
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+            [0.707, 0.707, 0.0],
+            [-0.707, 0.707, 0.0],
+            [0.707, -0.707, 0.0],
+            [-0.707, -0.707, 0.0],
+        ]
+    )
+    vecs = medial - seed
+
+    try:
+        hex_pts = _construct_from_vecs(vecs)
+    except np.linalg.LinAlgError:
+        pytest.fail("LinAlgError raised")
+
+    assert hex_pts.shape[0] == 6
+    directions = hex_pts - seed
+    unique = np.unique(directions, axis=0)
+    assert unique.shape[0] == 6
+


### PR DESCRIPTION
## Summary
- add regression test for `_construct_from_vecs` to ensure duplicate and nearly collinear medial vectors yield six unique directions without linear algebra errors

## Testing
- `pytest tests/design_api/uniform/test_sampler.py::test_construct_from_vecs_handles_duplicates_and_collinear -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8737261f88326af654ad5de533a5e