### PR TITLE
Fix uniform Voronoi preview generation

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -98,10 +98,15 @@ def compute_uniform_cells(
         cells: dict mapping seed index to (6,3) array of hexagon vertices.
     """
     # Build Delaunay triangulation to gather neighbor sets
-    delaunay = Delaunay(seeds)
     neighbor_sets: Dict[int, set] = {i: set() for i in range(len(seeds))}
-    for simplex in delaunay.simplices:
-        for i, j in itertools.combinations(simplex, 2):
+    if len(seeds) >= 4:
+        delaunay = Delaunay(seeds)
+        for simplex in delaunay.simplices:
+            for i, j in itertools.combinations(simplex, 2):
+                neighbor_sets[i].add(j)
+                neighbor_sets[j].add(i)
+    else:
+        for i, j in itertools.combinations(range(len(seeds)), 2):
             neighbor_sets[i].add(j)
             neighbor_sets[j].add(i)
 

--- a/tests/design_api/test_review_uniform.py
+++ b/tests/design_api/test_review_uniform.py
@@ -1,0 +1,63 @@
+import types
+import sys
+import numpy as np
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_review_generates_uniform_cells(monkeypatch):
+    dummy_inf = types.ModuleType("ai_adapter.inference_pipeline")
+    dummy_inf.generate = lambda prompt: "{}"
+    sys.modules.setdefault("ai_adapter.inference_pipeline", dummy_inf)
+
+    schema_pkg = types.ModuleType("ai_adapter.schema")
+    dummy_proto = types.ModuleType("ai_adapter.schema.implicitus_pb2")
+    class Dummy:
+        pass
+    for name in ["Primitive", "Modifier", "Infill", "Shell", "BooleanOp", "VoronoiLattice", "Model"]:
+        setattr(dummy_proto, name, Dummy)
+    sys.modules.setdefault("ai_adapter.schema", schema_pkg)
+    sys.modules.setdefault("ai_adapter.schema.implicitus_pb2", dummy_proto)
+
+    map_mod = types.ModuleType("design_api.services.mapping")
+    map_mod.map_primitive = lambda spec: spec
+    sys.modules.setdefault("design_api.services.mapping", map_mod)
+
+    validator_mod = types.ModuleType("design_api.services.validator")
+    validator_mod.validate_model_spec = lambda spec: spec
+    sys.modules.setdefault("design_api.services.validator", validator_mod)
+
+    csg_mod = types.ModuleType("ai_adapter.csg_adapter")
+    csg_mod.review_request = lambda req: ({}, "")
+    csg_mod.generate_summary = lambda *a, **k: ""
+    csg_mod.update_request = lambda *a, **k: ({}, "")
+    sys.modules.setdefault("ai_adapter.csg_adapter", csg_mod)
+
+    from design_api import main
+
+    spec = [{
+        "primitive": {"sphere": {"radius": 1.0}},
+        "modifiers": {
+            "infill": {
+                "pattern": "voronoi",
+                "uniform": True,
+                "seed_points": [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+                "bbox_min": [-1, -1, -1],
+                "bbox_max": [1, 1, 1]
+            }
+        }
+    }]
+
+    def fake_review_request(req):
+        return (spec, "summary")
+
+    monkeypatch.setattr(main, "review_request", fake_review_request)
+    monkeypatch.setattr(main, "log_turn", lambda *a, **k: None)
+
+    resp = await main.review({})
+    infill = resp["spec"][0]["modifiers"]["infill"]
+    cells = infill.get("cells")
+    assert cells and len(cells) == 3
+    for poly in cells:
+        assert len(poly) == 6
+        assert np.isfinite(poly).all()


### PR DESCRIPTION
## Summary
- generate Voronoi cells with uniform algorithm when `uniform` flag is set
- handle small seed sets when building neighbor graph
- add regression test ensuring review endpoint outputs uniform cells

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic tests/design_api/test_review_uniform.py::test_review_generates_uniform_cells -q`

------
https://chatgpt.com/codex/tasks/task_e_68a87ea0d75c8326a3be2f9dbbf85a0e