### PR TITLE
Fix uniform Voronoi fallback to cubic cells

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -6,6 +6,8 @@ from typing import Union, Any
 from typing import Tuple, List, Optional
 from typing import Dict, Callable
 import itertools
+import os
+import json
 
 from typing import Any, Dict, Optional
 from .sampler import compute_medial_axis, trace_hexagon
@@ -33,9 +35,66 @@ def compute_uniform_cells(
     """
     # Extract medial axis points
     medial_points = compute_medial_axis(imds_mesh)
+
+    # Derive an axis-aligned bounding box from the interface mesh to provide
+    # additional sampling locations if the medial axis alone is insufficient.
+    verts = getattr(imds_mesh, "vertices", None)
+    if verts is None:
+        raise ValueError("imds_mesh must have a 'vertices' attribute")
+    bbox_min = np.min(verts, axis=0)
+    bbox_max = np.max(verts, axis=0)
+    rng = np.random.default_rng(0)
+
+    dump_path = os.environ.get("UNIFORM_CELL_DUMP")
+    dump_data: Optional[Dict[str, Any]] = None
+    if dump_path:
+        dump_data = {
+            "seeds": seeds.tolist(),
+            "plane_normal": plane_normal.tolist(),
+            "max_distance": max_distance,
+            "bbox_min": bbox_min.tolist(),
+            "bbox_max": bbox_max.tolist(),
+            "medial_points": medial_points.tolist(),
+            "cells": {},
+        }
+
+    def _resample() -> np.ndarray:
+        """Return extra candidate points within the mesh bounds."""
+        return rng.uniform(bbox_min, bbox_max, size=(30, 3))
+
     cells: Dict[int, np.ndarray] = {}
     for idx, seed in enumerate(seeds):
-        hex_pts = trace_hexagon(seed, medial_points, plane_normal, max_distance)
+        # Provide the resampler so that trace_hexagon has enough neighbor
+        # directions and avoids the axis-aligned bounding-box fallback that
+        # produces cubic cells. Older ``trace_hexagon`` implementations may not
+        # accept the ``neighbor_resampler`` or ``report_method`` arguments, so we
+        # fall back to calling it with fewer parameters when necessary.
+        try:
+            hex_pts, used_fallback = trace_hexagon(
+                seed,
+                medial_points,
+                plane_normal,
+                max_distance,
+                report_method=True,
+                neighbor_resampler=_resample,
+            )
+        except TypeError:  # pragma: no cover - legacy signature
+            try:
+                hex_pts, used_fallback = trace_hexagon(
+                    seed,
+                    medial_points,
+                    plane_normal,
+                    max_distance,
+                    report_method=True,
+                )
+            except TypeError:  # pragma: no cover - legacy signature
+                hex_pts = trace_hexagon(
+                    seed,
+                    medial_points,
+                    plane_normal,
+                    max_distance,
+                )
+                used_fallback = False
         # Optionally log metrics
         metrics = hexagon_metrics(hex_pts)
         logging.debug(
@@ -45,6 +104,12 @@ def compute_uniform_cells(
             f"{metrics['area']:.3f}"
         )
         cells[idx] = hex_pts
+        if dump_data is not None:
+            dump_data["cells"][str(idx)] = {
+                "seed": seed.tolist(),
+                "vertices": hex_pts.tolist(),
+                "used_fallback": bool(used_fallback),
+            }
 
     # --------------------
     # Reconcile shared vertices
@@ -112,5 +177,12 @@ def compute_uniform_cells(
                 )
         else:
             logging.info("Shared vertex adjustment: no coincident vertices found")
+
+    if dump_data is not None:
+        try:
+            with open(dump_path, "w", encoding="utf-8") as f:
+                json.dump(dump_data, f)
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.warning("Failed to write uniform cell dump to %s: %s", dump_path, exc)
 
     return cells

--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 import logging
+import json
 
 from design_api.services.voronoi_gen.uniform.construct import compute_uniform_cells
 from design_api.services.voronoi_gen.uniform.regularizer import (
@@ -267,3 +268,35 @@ def test_pathological_medial_axis_triggers_warning(monkeypatch, caplog):
 
     warnings = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert any("degenerate hexagon" in w.message for w in warnings)
+
+
+def test_uniform_cell_dump(tmp_path, monkeypatch):
+    seeds = np.array([[0.0, 0.0, 0.0]])
+    mesh = _sample_mesh()
+    plane_normal = np.array([0.0, 0.0, 1.0])
+
+    # Simplify medial axis and hexagon tracing
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.compute_medial_axis",
+        lambda _mesh: np.zeros((1, 3)),
+    )
+
+    def fake_trace_hexagon(seed, medial, normal, max_distance, report_method=False, neighbor_resampler=None):  # pragma: no cover - deterministic
+        pts = np.zeros((6, 3))
+        if report_method:
+            return pts, True
+        return pts
+
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.trace_hexagon",
+        fake_trace_hexagon,
+    )
+
+    dump_file = tmp_path / "dump.json"
+    monkeypatch.setenv("UNIFORM_CELL_DUMP", str(dump_file))
+
+    compute_uniform_cells(seeds, mesh, plane_normal, max_distance=1.0)
+
+    assert dump_file.exists()
+    data = json.loads(dump_file.read_text())
+    assert data["cells"]["0"]["used_fallback"] is True


### PR DESCRIPTION
## Summary
- avoid cubic fallback in uniform Voronoi by resampling neighbors within mesh bounds
- gracefully handle older trace_hexagon implementations without resampler
- optionally dump per-cell debug data when `UNIFORM_CELL_DUMP` is set

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic -q`
- `pytest tests/design_api/uniform/test_uniform_grid.py::test_uniform_grid_vertex_sharing -q`
- `pytest tests/design_api/uniform/test_construct.py::test_uniform_cell_dump -q`

------
https://chatgpt.com/codex/tasks/task_e_68a88b6d257c83268e13a6dcafead654