### PR TITLE
Write uniform cell dump to logs directory

### DIFF
--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pytest
 import logging
+import json
+from pathlib import Path
 
 from design_api.services.voronoi_gen.uniform.construct import compute_uniform_cells
 from design_api.services.voronoi_gen.uniform.regularizer import (
@@ -267,3 +269,42 @@ def test_pathological_medial_axis_triggers_warning(monkeypatch, caplog):
 
     warnings = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert any("degenerate hexagon" in w.message for w in warnings)
+
+
+def test_uniform_cell_dump(monkeypatch):
+    seeds = np.array([[0.0, 0.0, 0.0]])
+    mesh = _sample_mesh()
+    plane_normal = np.array([0.0, 0.0, 1.0])
+
+    # Simplify medial axis and hexagon tracing
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.compute_medial_axis",
+        lambda _mesh: np.zeros((1, 3)),
+    )
+
+    def fake_trace_hexagon(seed, medial, normal, max_distance, report_method=False, neighbor_resampler=None):  # pragma: no cover - deterministic
+        pts = np.zeros((6, 3))
+        if report_method:
+            return pts, True
+        return pts
+
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.trace_hexagon",
+        fake_trace_hexagon,
+    )
+
+    dump_file = Path(__file__).resolve().parents[3] / "logs" / "UNIFORM_CELL_DUMP.json"
+    if dump_file.exists():
+        dump_file.unlink()
+
+    compute_uniform_cells(
+        seeds,
+        mesh,
+        plane_normal,
+        max_distance=1.0,
+    )
+
+    assert dump_file.exists()
+    data = json.loads(dump_file.read_text())
+    assert data["cells"]["0"]["used_fallback"] is True
+    dump_file.unlink()


### PR DESCRIPTION
## Summary
- Emit `UNIFORM_CELL_DUMP.json` into the repo's `logs` directory and ensure it exists
- Adjust uniform cell dump test to validate new output path and clean up after

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic -q`
- `pytest tests/design_api/uniform/test_uniform_grid.py::test_uniform_grid_vertex_sharing -q`
- `pytest tests/design_api/uniform/test_construct.py::test_uniform_cell_dump -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88b6d257c83268e13a6dcafead654