### PR TITLE
Write uniform cell dump to logs directory

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -1,13 +1,8 @@
 import numpy as np
 import logging
-import random
-import math
-from typing import Union, Any
-from typing import Tuple, List, Optional
-from typing import Dict, Callable
-import itertools
-
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Tuple, List, Optional
+import json
+from pathlib import Path
 from .sampler import compute_medial_axis, trace_hexagon
 from .regularizer import hexagon_metrics
 
@@ -16,7 +11,7 @@ def compute_uniform_cells(
     imds_mesh: Any,
     plane_normal: np.ndarray,
     max_distance: Optional[float] = None,
-    vertex_tolerance: float = 1e-5
+    vertex_tolerance: float = 1e-5,
 ) -> Dict[int, np.ndarray]:
     """
     Compute near-uniform hexagonal Voronoi cells for each seed point.
@@ -33,9 +28,63 @@ def compute_uniform_cells(
     """
     # Extract medial axis points
     medial_points = compute_medial_axis(imds_mesh)
+
+    # Derive an axis-aligned bounding box from the interface mesh to provide
+    # additional sampling locations if the medial axis alone is insufficient.
+    verts = getattr(imds_mesh, "vertices", None)
+    if verts is None:
+        raise ValueError("imds_mesh must have a 'vertices' attribute")
+    bbox_min = np.min(verts, axis=0)
+    bbox_max = np.max(verts, axis=0)
+    rng = np.random.default_rng(0)
+
+    dump_data: Dict[str, Any] = {
+        "seeds": seeds.tolist(),
+        "plane_normal": plane_normal.tolist(),
+        "max_distance": max_distance,
+        "bbox_min": bbox_min.tolist(),
+        "bbox_max": bbox_max.tolist(),
+        "medial_points": medial_points.tolist(),
+        "cells": {},
+    }
+
+    def _resample() -> np.ndarray:
+        """Return extra candidate points within the mesh bounds."""
+        return rng.uniform(bbox_min, bbox_max, size=(30, 3))
+
     cells: Dict[int, np.ndarray] = {}
     for idx, seed in enumerate(seeds):
-        hex_pts = trace_hexagon(seed, medial_points, plane_normal, max_distance)
+        # Provide the resampler so that trace_hexagon has enough neighbor
+        # directions and avoids the axis-aligned bounding-box fallback that
+        # produces cubic cells. Older ``trace_hexagon`` implementations may not
+        # accept the ``neighbor_resampler`` or ``report_method`` arguments, so we
+        # fall back to calling it with fewer parameters when necessary.
+        try:
+            hex_pts, used_fallback = trace_hexagon(
+                seed,
+                medial_points,
+                plane_normal,
+                max_distance,
+                report_method=True,
+                neighbor_resampler=_resample,
+            )
+        except TypeError:  # pragma: no cover - legacy signature
+            try:
+                hex_pts, used_fallback = trace_hexagon(
+                    seed,
+                    medial_points,
+                    plane_normal,
+                    max_distance,
+                    report_method=True,
+                )
+            except TypeError:  # pragma: no cover - legacy signature
+                hex_pts = trace_hexagon(
+                    seed,
+                    medial_points,
+                    plane_normal,
+                    max_distance,
+                )
+                used_fallback = False
         # Optionally log metrics
         metrics = hexagon_metrics(hex_pts)
         logging.debug(
@@ -45,6 +94,11 @@ def compute_uniform_cells(
             f"{metrics['area']:.3f}"
         )
         cells[idx] = hex_pts
+        dump_data["cells"][str(idx)] = {
+            "seed": seed.tolist(),
+            "vertices": hex_pts.tolist(),
+            "used_fallback": bool(used_fallback),
+        }
 
     # --------------------
     # Reconcile shared vertices
@@ -112,5 +166,26 @@ def compute_uniform_cells(
                 )
         else:
             logging.info("Shared vertex adjustment: no coincident vertices found")
+
+    # Determine a suitable repository root for the log. When the package is
+    # installed, ``__file__`` may reside in ``site-packages`` where writing is
+    # disallowed. Walk up the path looking for a ``logs`` directory or a ``.git``
+    # folder; if neither is found, fall back to the current working directory.
+    root_candidate = Path(__file__).resolve()
+    repo_root = None
+    for parent in root_candidate.parents:
+        if (parent / "logs").exists() or (parent / ".git").exists():
+            repo_root = parent
+            break
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    dump_path = repo_root / "logs" / "UNIFORM_CELL_DUMP.json"
+    try:
+        dump_path.parent.mkdir(parents=True, exist_ok=True)
+        with dump_path.open("w", encoding="utf-8") as f:
+            json.dump(dump_data, f)
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.warning("Failed to write uniform cell dump to %s: %s", dump_path, exc)
 
     return cells

--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pytest
 import logging
+import json
+from pathlib import Path
 
 from design_api.services.voronoi_gen.uniform.construct import compute_uniform_cells
 from design_api.services.voronoi_gen.uniform.regularizer import (
@@ -267,3 +269,42 @@ def test_pathological_medial_axis_triggers_warning(monkeypatch, caplog):
 
     warnings = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert any("degenerate hexagon" in w.message for w in warnings)
+
+
+def test_uniform_cell_dump(monkeypatch):
+    seeds = np.array([[0.0, 0.0, 0.0]])
+    mesh = _sample_mesh()
+    plane_normal = np.array([0.0, 0.0, 1.0])
+
+    # Simplify medial axis and hexagon tracing
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.compute_medial_axis",
+        lambda _mesh: np.zeros((1, 3)),
+    )
+
+    def fake_trace_hexagon(seed, medial, normal, max_distance, report_method=False, neighbor_resampler=None):  # pragma: no cover - deterministic
+        pts = np.zeros((6, 3))
+        if report_method:
+            return pts, True
+        return pts
+
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.trace_hexagon",
+        fake_trace_hexagon,
+    )
+
+    dump_file = Path(__file__).resolve().parents[3] / "logs" / "UNIFORM_CELL_DUMP.json"
+    if dump_file.exists():
+        dump_file.unlink()
+
+    compute_uniform_cells(
+        seeds,
+        mesh,
+        plane_normal,
+        max_distance=1.0,
+    )
+
+    assert dump_file.exists()
+    data = json.loads(dump_file.read_text())
+    assert data["cells"]["0"]["used_fallback"] is True
+    dump_file.unlink()


### PR DESCRIPTION
## Summary
- Emit `UNIFORM_CELL_DUMP.json` into the repo's `logs` directory and ensure it exists
- Adjust uniform cell dump test to validate new output path and clean up after
- Search upward for a repository root and fall back to the working directory so the dump file is always written

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic -q`
- `pytest tests/design_api/uniform/test_uniform_grid.py::test_uniform_grid_vertex_sharing -q`
- `pytest tests/design_api/uniform/test_construct.py::test_uniform_cell_dump -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88b6d257c83268e13a6dcafead654