### PR TITLE
Add raw std edge limit with resampling

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,14 @@
+
+## Voronoi Generation Parameters
+
+`compute_uniform_cells` accepts several optional limits to guard against
+pathological cells:
+
+- `mean_edge_limit` – maximum allowed mean edge length for a traced cell.
+- `area_limit` – maximum allowed polygon area.
+- `raw_std_edge_limit` – caps the standard deviation of edge lengths. If the
+  initial polygon exceeds this value the function resamples once before
+  dropping the seed.
+
+Any cell exceeding these thresholds after the retry is omitted and reported as
+failed.


### PR DESCRIPTION
## Summary
- allow callers to bound raw edge-length variance via `raw_std_edge_limit`
- resample seeds once when raw standard deviation exceeds the new limit
- document voronoi limit options and add regression test

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_raw_std_edge_limit_resamples -q`
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic -q`
- `pytest tests/design_api/uniform/test_uniform_grid.py::test_uniform_grid_vertex_sharing -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a2e06fc83268dc66ecf759b833f