### PR TITLE
Log neighbor diagnostics for rejected uniform cells

### DIFF
--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -449,6 +449,8 @@ def test_metric_threshold_warning_and_status(monkeypatch, caplog):
     assert info["seed"] == [0.0, 0.0, 0.0]
     assert info["neighbor_count"] >= 1
     assert info["used_fallback"] is False
+    assert len(info["neighbor_distances"]) == info["neighbor_count"]
+    assert len(info["neighbor_angles"]) == info["neighbor_count"]
 
     data = json.loads(dump_file.read_text())
     dump_info = data["failed_indices"][0]
@@ -456,6 +458,8 @@ def test_metric_threshold_warning_and_status(monkeypatch, caplog):
     assert dump_info["seed"] == [0.0, 0.0, 0.0]
     assert dump_info["neighbor_count"] >= 1
     assert dump_info["used_fallback"] is False
+    assert len(dump_info["neighbor_distances"]) == dump_info["neighbor_count"]
+    assert len(dump_info["neighbor_angles"]) == dump_info["neighbor_count"]
     dump_file.unlink()
     warnings = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert any(


### PR DESCRIPTION
## Summary
- compute and record neighbor distances and angular distribution when a uniform cell is dropped
- include these diagnostics in `failed_indices` output and JSON dump
- expand tests to verify logging of neighbor metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a2d06188326ab6c3b3a7bf4b7bf