### PR TITLE
Log bounding-box fallback seeds and add regression test

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -351,7 +351,7 @@ def compute_uniform_cells(
 
         if used_fallback:
             fallback_indices.append(idx)
-            logger.warning("Seed %d used trace_hexagon fallback", idx)
+            logger.warning("Seed %d at %s used trace_hexagon fallback", idx, seed.tolist())
             extra_pts = _resample()
             neighbors = np.vstack([medial_points, extra_pts])
             neighbor_count = neighbors.shape[0]
@@ -368,7 +368,7 @@ def compute_uniform_cells(
                 metrics = hexagon_metrics(raw_hex)
                 if used_fallback:
                     logger.error(
-                        "Fallback used after resampling for seed %d", idx
+                        "Fallback used after resampling for seed %d at %s", idx, seed.tolist()
                     )
             except TypeError:  # pragma: no cover - legacy signature
                 hex_pts = trace_hexagon(

--- a/design_api/services/voronoi_gen/uniform/sampler.py
+++ b/design_api/services/voronoi_gen/uniform/sampler.py
@@ -294,7 +294,10 @@ def trace_hexagon(
         hex_pts = hex_pts_arr
         hex_success = True
     else:
-        logging.warning("trace_hexagon: using bounding-box fallback; consider resampling or expanding search radius")
+        logging.warning(
+            "trace_hexagon: using bounding-box fallback at seed %s",
+            seed_pt.tolist(),
+        )
         angles = np.linspace(0, 2 * np.pi, 6, endpoint=False)
         for theta in angles:
             dir_vec = np.cos(theta) * u + np.sin(theta) * v

--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -393,6 +393,33 @@ def test_uniform_cell_dump(monkeypatch):
     dump_file.unlink()
 
 
+def test_fallback_indices_recorded(monkeypatch):
+    seeds = np.array([[0.0, 0.0, 0.0]])
+    mesh = DummyMesh([[0.0, 0.0, 0.0]])
+    plane_normal = np.array([0.0, 0.0, 1.0])
+
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.compute_medial_axis",
+        lambda _mesh: np.zeros((1, 3)),
+    )
+
+    dump_file = Path(__file__).resolve().parents[3] / "logs" / "UNIFORM_CELL_DUMP.json"
+    if dump_file.exists():
+        dump_file.unlink()
+
+    compute_uniform_cells(
+        seeds,
+        mesh,
+        plane_normal,
+        max_distance=1.0,
+        resample_points=0,
+    )
+
+    data = json.loads(dump_file.read_text())
+    assert data["fallback_indices"] == [0]
+    assert data["cells"]["0"]["used_fallback"] is True
+    dump_file.unlink()
+
 def test_metric_threshold_warning_and_status(monkeypatch, caplog):
     """Pathological hexagons should trigger metric threshold warnings."""
 


### PR DESCRIPTION
## Summary
- log seed coordinates when `trace_hexagon` falls back to bounding-box rays
- surface fallback seed indices and coordinates in `compute_uniform_cells`
- add regression test ensuring fallback indices are recorded in cell dump

## Testing
- `pytest tests/design_api/uniform/test_sampler.py::test_trace_hexagon_fallback tests/design_api/uniform/test_sampler.py::test_trace_hexagon_medial_one_side_bbox tests/design_api/uniform/test_construct.py::test_uniform_cell_dump tests/design_api/uniform/test_construct.py::test_fallback_indices_recorded -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a2b413c8326b8c62277da24f9b7