### PR TITLE
Guard uniform cell metrics against global limits

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -203,6 +203,9 @@ def compute_uniform_cells(
         # accept the ``neighbor_resampler`` or ``report_method`` arguments, so we
         # fall back to calling it with fewer parameters when necessary.
 
+        neighbors = medial_points
+        neighbor_count = neighbors.shape[0]
+
         def _check_limits(metrics: Dict[str, float], level: int = logging.WARNING) -> bool:
             exceeded_local = False
             if mean_edge_limit is not None and metrics["mean_edge_length"] > mean_edge_limit:
@@ -237,7 +240,7 @@ def compute_uniform_cells(
             hex_pts, used_fallback, raw_hex = trace_hexagon(
 
                 seed,
-                medial_points,
+                neighbors,
                 plane_normal,
                 max_distance,
 
@@ -249,7 +252,7 @@ def compute_uniform_cells(
             try:
                 hex_pts, used_fallback, raw_hex = trace_hexagon(
                     seed,
-                    medial_points,
+                    neighbors,
                     plane_normal,
                     max_distance,
                     report_method=True,
@@ -259,7 +262,7 @@ def compute_uniform_cells(
                 try:
                     hex_pts, used_fallback = trace_hexagon(
                         seed,
-                        medial_points,
+                        neighbors,
                         plane_normal,
                         max_distance,
                         report_method=True,
@@ -268,7 +271,7 @@ def compute_uniform_cells(
                 except TypeError:  # pragma: no cover - legacy signature
                     hex_pts = trace_hexagon(
                         seed,
-                        medial_points,
+                        neighbors,
                         plane_normal,
                         max_distance,
                     )
@@ -444,6 +447,21 @@ def compute_uniform_cells(
                 logger.error("Skipping cell %d due to metric limits", idx)
                 continue
 
+
+        # Final safeguard before acceptance
+        if _check_outlier(metrics, idx, level=logging.ERROR) or _check_limits(metrics, level=logging.ERROR):
+            failed_indices.append(
+                {
+                    "index": idx,
+                    "seed": seed.tolist(),
+                    "neighbor_count": int(neighbor_count),
+                    "used_fallback": bool(used_fallback),
+                    **_neighbor_diagnostics(neighbors),
+                }
+            )
+            status = 1
+            logger.error("Skipping cell %d due to metric limits", idx)
+            continue
 
         # Optionally log metrics (throttled to avoid flooding output)
         if logger.isEnabledFor(logging.DEBUG) and (idx < 10 or idx % 1000 == 0):

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -9,6 +9,12 @@ pathological cells:
 - `raw_std_edge_limit` – caps the standard deviation of edge lengths. If the
   initial polygon exceeds this value the function resamples once before
   dropping the seed.
+- `mean_edge_factor` – multiplier applied to the running global average of
+  `mean_edge_length`. Cells exceeding this factor times the global mean are
+  resampled once before being discarded.
+- `std_edge_factor` – multiplier on the global average of `std_edge_length`.
+  Like `mean_edge_factor`, cells whose raw edge standard deviation exceeds the
+  scaled global mean are retried once and skipped if still out of bounds.
 
 Any cell exceeding these thresholds after the retry is omitted and reported as
 failed.


### PR DESCRIPTION
## Summary
- recheck raw edge mean and std against global thresholds before accepting uniform cells
- document `mean_edge_factor` and `std_edge_factor`
- add test for high-variance seed resampling and rejection

## Testing
- `pytest tests/design_api/uniform/test_construct.py::test_global_outlier_resample_then_skip -q`
- `pytest tests/design_api/uniform/test_construct.py::test_raw_std_edge_limit_resamples -q`
- `pytest tests/design_api/uniform/test_construct.py::test_compute_uniform_cells_basic -q`
- `pytest tests/design_api/uniform/test_uniform_grid.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab559621dc8326802da614945c9377