### PR TITLE
Log trace_hexagon fallback

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -233,6 +233,12 @@ def compute_uniform_cells(
                 )
                 exceeded_local = True
             return exceeded_local
+
+        def _log_fallback(flag: bool) -> None:
+            if flag:
+                logger.warning(
+                    "Seed %d at %s used trace_hexagon fallback", idx, seed.tolist()
+                )
         try:
             hex_pts, used_fallback, raw_hex = trace_hexagon(
 
@@ -275,6 +281,8 @@ def compute_uniform_cells(
                     used_fallback = False
                     raw_hex = hex_pts.copy()
 
+        _log_fallback(used_fallback)
+
 
         metrics = hexagon_metrics(raw_hex)
         if _check_outlier(metrics, idx):
@@ -310,6 +318,7 @@ def compute_uniform_cells(
                     )
                     used_fallback = False
                     raw_hex = hex_pts.copy()
+            _log_fallback(used_fallback)
             metrics = hexagon_metrics(raw_hex)
             if _check_outlier(metrics, idx, level=logging.ERROR):
                 failed_indices.append(
@@ -358,6 +367,7 @@ def compute_uniform_cells(
                     )
                     used_fallback = False
                     raw_hex = hex_pts.copy()
+            _log_fallback(used_fallback)
             metrics = hexagon_metrics(raw_hex)
             if _check_outlier(metrics, idx, level=logging.ERROR):
                 failed_indices.append(
@@ -388,7 +398,6 @@ def compute_uniform_cells(
 
         if used_fallback:
             fallback_indices.append(idx)
-            logger.warning("Seed %d at %s used trace_hexagon fallback", idx, seed.tolist())
             extra_pts = _resample()
             neighbors = np.vstack([medial_points, extra_pts])
             neighbor_count = neighbors.shape[0]
@@ -402,6 +411,7 @@ def compute_uniform_cells(
                     neighbor_resampler=_resample,
                     return_raw=True,
                 )
+                _log_fallback(used_fallback)
                 metrics = hexagon_metrics(raw_hex)
                 if used_fallback:
                     logger.error(

--- a/tests/design_api/uniform/test_construct.py
+++ b/tests/design_api/uniform/test_construct.py
@@ -79,6 +79,30 @@ def test_no_fallback_for_sample_mesh():
     dump_file.unlink()
 
 
+def test_logs_warning_when_fallback_used(monkeypatch, caplog):
+    seeds = np.array([[0.0, 0.0, 0.0]])
+    mesh = DummyMesh([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.uniform.construct.compute_medial_axis",
+        lambda _mesh: np.zeros((1, 3)),
+    )
+
+    plane_normal = np.array([0.0, 0.0, 1.0])
+    with caplog.at_level(logging.WARNING):
+        compute_uniform_cells(
+            seeds,
+            mesh,
+            plane_normal,
+            max_distance=1.0,
+            resample_points=0,
+        )
+
+    assert any(
+        "used trace_hexagon fallback" in rec.message for rec in caplog.records
+    )
+
+
 def test_cell_planes_align_with_normal():
     """Seeds offset from the slicing plane should still yield coplanar cells."""
 


### PR DESCRIPTION
## Summary
- log whenever `trace_hexagon` reports using its bounding-box fallback
- cover fallback logging with a dedicated unit test

## Testing
- `pytest tests/design_api/uniform/test_construct.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5593a6148326bb57e259dfdcd624