### PR TITLE
Warn when Voronoi edges are missing

### DIFF
--- a/implicitus-ui/package.json
+++ b/implicitus-ui/package.json
@@ -36,6 +36,8 @@
     "vite": "^6.3.5",
     "vite-plugin-babel-macros": "^1.0.6",
     "vitest": "^2.1.3",
-    "graphlib": "^2.1.8"
+    "graphlib": "^2.1.8",
+    "@testing-library/react": "^16.1.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/implicitus-ui/src/components/VoronoiCanvas.test.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.test.tsx
@@ -1,5 +1,9 @@
+// @vitest-environment jsdom
+import React from 'react';
 import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { generateHexTest3D, computeFilteredEdges } from './VoronoiCanvas';
+import VoronoiCanvas from './VoronoiCanvas';
 import { Graph, alg } from 'graphlib';
 
 describe('VoronoiCanvas filteredEdges', () => {
@@ -28,5 +32,14 @@ describe('VoronoiCanvas filteredEdges', () => {
     filtered.forEach(([i, j]) => g.setEdge(String(i), String(j)));
     const components = alg.components(g);
     expect(components.length).toBe(1);
+  });
+});
+
+describe('VoronoiCanvas warning', () => {
+  it('renders a warning banner when no edges are provided', () => {
+    render(
+      <VoronoiCanvas seedPoints={[]} edges={[]} bbox={[0, 0, 0, 1, 1, 1]} />
+    );
+    expect(screen.getByTestId('no-edges-warning')).toBeTruthy();
   });
 });

--- a/implicitus-ui/src/components/VoronoiCanvas.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.tsx
@@ -164,6 +164,10 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
   cells = [],
   edgeLengthThreshold = 1.5,
 }) => {
+  const noEdges = edges.length === 0;
+  if (noEdges) {
+    console.warn('VoronoiCanvas: no edges provided');
+  }
   // In debug mode, hide the ray-march solid box
   if (DEBUG_HEX_TEST) showSolid = false;
   DEBUG_CANVAS && console.log('VoronoiCanvas debug props:', { seedPoints, edges, bbox });
@@ -335,25 +339,36 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
   }, [validCells, validSeedPoints]);
 
   return (
-    <div style={{
-      width: '100%',
-      height: '400px',
-      maxHeight: '400px',
-      minHeight: 0,
-      overflow: 'hidden',
-      position: 'relative',
-      flexShrink: 0
-    }}>
-      <Canvas
-        style={{ width: '100%', height: '100%', display: 'block' }}
-        resize={{ scroll: false }}
-        gl={{ version: 2 }}
-        camera={{ position: [15, 15, 15], fov: 60 }}
-      >
-        {showStruts ? (
-          showSolid && (
-            // Simple box for Strut view
-            <mesh
+    <div
+      style={{
+        width: '100%',
+        height: '400px',
+        maxHeight: '400px',
+        minHeight: 0,
+        overflow: 'hidden',
+        position: 'relative',
+        flexShrink: 0
+      }}
+    >
+      {noEdges ? (
+        <div
+          className="warning-banner"
+          role="alert"
+          data-testid="no-edges-warning"
+        >
+          No edges were returned; unable to render Voronoi mesh.
+        </div>
+      ) : (
+        <Canvas
+          style={{ width: '100%', height: '100%', display: 'block' }}
+          resize={{ scroll: false }}
+          gl={{ version: 2 }}
+          camera={{ position: [15, 15, 15], fov: 60 }}
+        >
+          {showStruts ? (
+            showSolid && (
+              // Simple box for Strut view
+              <mesh
               position={[
                 (bbox[0] + bbox[3]) / 2,
                 (bbox[1] + bbox[4]) / 2,
@@ -458,8 +473,9 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
         )}
         */}
         <OrbitControls />
-        
-      </Canvas>
+
+        </Canvas>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Show a warning banner instead of rendering when Voronoi edges are absent
- Log missing edges and add unit test
- Add testing utilities for React component tests

## Testing
- `npm test` (implicitus-ui)
- `npm run lint` (implicitus-ui) *(fails: React Hooks called conditionally in existing files)*
- `pytest -q` *(fails: missing python dependencies like numpy, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6fd5cb148326a9321e5acb9736fe