### PR TITLE
Add uniform cell dump utility and regression test

### DIFF
--- a/design_api/services/voronoi_gen/uniform/construct.py
+++ b/design_api/services/voronoi_gen/uniform/construct.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+import os
 
 from typing import Any, Dict, Tuple, List, Optional, Union
 import json
@@ -9,6 +10,43 @@ from .sampler import compute_medial_axis, trace_hexagon
 from .regularizer import hexagon_metrics
 
 logger = logging.getLogger(__name__)
+
+
+def dump_uniform_cell_map(dump_data: Dict[str, Any]) -> None:
+    """Persist uniform generation diagnostics to ``UNIFORM_CELL_DUMP.json``.
+
+    The dump is written relative to the repository root if possible; otherwise
+    the current working directory is used.  A best effort is made to ensure the
+    destination directory exists and is writable.  Any failure is logged at
+    ``WARNING`` level while successful writes are logged at ``INFO``.
+    """
+
+    # Determine a suitable repository root. When the package is installed the
+    # source may live under ``site-packages`` where writing is disallowed. Walk
+    # up the path looking for a ``logs`` directory or a ``.git`` folder; if
+    # neither is found, fall back to the current working directory.
+    root_candidate = Path(__file__).resolve()
+    repo_root = None
+    for parent in root_candidate.parents:
+        if (parent / "logs").exists() or (parent / ".git").exists():
+            repo_root = parent
+            break
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    logging.debug("REPO ROOT: %s", repo_root)
+
+    dump_path = repo_root / "logs" / "UNIFORM_CELL_DUMP.json"
+    try:
+        dump_path.parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(dump_path.parent, os.W_OK):
+            logging.warning("Uniform cell dump path %s is not writable", dump_path)
+            return
+        with dump_path.open("w", encoding="utf-8") as f:
+            json.dump(dump_data, f)
+        logging.info("Uniform cell dump written to %s", dump_path)
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.warning("Failed to write uniform cell dump to %s: %s", dump_path, exc)
 
 def compute_uniform_cells(
     seeds: np.ndarray,
@@ -638,33 +676,7 @@ def compute_uniform_cells(
         else:
             logger.info("No edges generated; all cells were skipped")
 
-    # Determine a suitable repository root for the log. When the package is
-    # installed, ``__file__`` may reside in ``site-packages`` where writing is
-    # disallowed. Walk up the path looking for a ``logs`` directory or a ``.git``
-    # folder; if neither is found, fall back to the current working directory.
-    root_candidate = Path(__file__).resolve()
-    repo_root = None
-    for parent in root_candidate.parents:
-        if (parent / "logs").exists() or (parent / ".git").exists():
-            repo_root = parent
-            break
-    if repo_root is None:
-        repo_root = Path.cwd()
-
-    # Explicitly log the resolved repository root for troubleshooting. The
-    # previous call used a comma which resulted in a formatting error when the
-    # logger was configured for DEBUG. Using "%s" ensures the path is rendered
-    # correctly without raising a logging exception.
-    logging.debug("REPO ROOT: %s", repo_root)
-    
-    dump_path = repo_root / "logs" / "UNIFORM_CELL_DUMP.json"
-    try:
-        dump_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with dump_path.open("w", encoding="utf-8") as f:
-            json.dump(dump_data, f)
-    except Exception as exc:  # pragma: no cover - best effort
-        logging.warning("Failed to write uniform cell dump to %s: %s", dump_path, exc)
+    dump_uniform_cell_map(dump_data)
     if return_status and return_edges:
         return cells, edges, status, failed_indices
     if return_status:


### PR DESCRIPTION
## Summary
- extract uniform cell dump logic into `dump_uniform_cell_map` and log successful writes
- call dump utility after uniform generation with writable path check
- add regression test asserting `UNIFORM_CELL_DUMP.json` is created and non-empty

## Testing
- `pytest tests/design_api/uniform/test_construct.py -q`
- `pytest -q` *(fails: No module named 'google', 'fastapi', 'transformers', 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68ab6fd9b11c8326899d5890acc75d52