### PR TITLE
Return uniform Voronoi edge list and add regression test

### DIFF
--- a/design_api/services/voronoi_gen/voronoi_gen.py
+++ b/design_api/services/voronoi_gen/voronoi_gen.py
@@ -432,7 +432,9 @@ def build_hex_lattice(
         if mode == "uniform":
             from .uniform.construct import compute_uniform_cells
 
-            cells = compute_uniform_cells(np.asarray(pts), **cell_kwargs)
+            cells, edge_list = compute_uniform_cells(
+                np.asarray(pts), return_edges=True, **cell_kwargs
+            )
         else:
             from .organic.construct import construct_voronoi_cells
 

--- a/tests/design_api/uniform/test_review_edges.py
+++ b/tests/design_api/uniform/test_review_edges.py
@@ -1,0 +1,77 @@
+import types
+import sys
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_review_returns_edges(monkeypatch):
+    transformers_stub = types.ModuleType("transformers")
+    transformers_stub.pipeline = lambda *args, **kwargs: None
+    transformers_stub.AutoTokenizer = object
+    sys.modules.setdefault("transformers", transformers_stub)
+
+    ai_adapter_mod = types.ModuleType("ai_adapter")
+    ai_adapter_mod.__path__ = []  # mark as package
+    schema_mod = types.ModuleType("ai_adapter.schema")
+    schema_mod.__path__ = []
+    pb2_mod = types.ModuleType("ai_adapter.schema.implicitus_pb2")
+    for name in [
+        "Primitive",
+        "Modifier",
+        "Infill",
+        "Shell",
+        "BooleanOp",
+        "VoronoiLattice",
+    ]:
+        setattr(pb2_mod, name, object)
+    schema_mod.implicitus_pb2 = pb2_mod
+    ai_adapter_mod.schema = schema_mod
+    csg_mod = types.ModuleType("ai_adapter.csg_adapter")
+    csg_mod.review_request = lambda req: ({}, "")
+    csg_mod.generate_summary = lambda *args, **kwargs: ""
+    csg_mod.update_request = lambda *args, **kwargs: ({}, "")
+    ai_adapter_mod.csg_adapter = csg_mod
+    inference_mod = types.ModuleType("ai_adapter.inference_pipeline")
+    inference_mod.generate = lambda *args, **kwargs: ""
+    ai_adapter_mod.inference_pipeline = inference_mod
+    sys.modules.setdefault("ai_adapter", ai_adapter_mod)
+    sys.modules.setdefault("ai_adapter.schema", schema_mod)
+    sys.modules.setdefault("ai_adapter.schema.implicitus_pb2", pb2_mod)
+    sys.modules.setdefault("ai_adapter.csg_adapter", csg_mod)
+    sys.modules.setdefault("ai_adapter.inference_pipeline", inference_mod)
+
+    validator_stub = types.ModuleType("design_api.services.validator")
+    validator_stub.validate_model_spec = lambda spec: spec
+    sys.modules.setdefault("design_api.services.validator", validator_stub)
+
+    from design_api.main import app
+    import design_api.main as design_main
+
+    client = TestClient(app)
+    def fake_review_request(req):
+        spec = [
+            {
+                "primitive": {"sphere": {"radius": 1.0}},
+                "modifiers": {
+                    "infill": {
+                        "pattern": "voronoi",
+                        "mode": "uniform",
+                        "spacing": 1.0,
+                        "seed_points": [[0.0, 0.0, 0.0]],
+                        "bbox_min": [-1.0, -1.0, -1.0],
+                        "bbox_max": [1.0, 1.0, 1.0],
+                    }
+                },
+            }
+        ]
+        return spec, "summary"
+
+    monkeypatch.setattr(design_main, "review_request", fake_review_request)
+    monkeypatch.setattr(design_main, "log_turn", lambda *args, **kwargs: None)
+
+    resp = client.post("/design/review", json={})
+    assert resp.status_code == 200
+    data = resp.json()
+    edges = data["spec"][0]["modifiers"]["infill"]["edges"]
+    assert isinstance(edges, list)
+    assert len(edges) > 0


### PR DESCRIPTION
## Summary
- request edges from `compute_uniform_cells` so build_hex_lattice returns reconciled edge list
- regression test ensures `/design/review` exposes non-empty `edges` array when seeds are provided

## Testing
- `pytest tests/design_api/uniform/test_review_edges.py -q`
- `pytest tests/design_api/test_build_hex_lattice.py::test_build_hex_lattice_returns_cells -q`
- `pytest tests/design_api/test_build_hex_lattice.py::test_build_hex_lattice_midpoints -q`
- `pytest tests/design_api/test_uniform_auto_mesh.py -q`
- `pytest tests/design_api/test_hex_lattice_structure.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d36b5cc8326a2b9a2da280b2cce