### PR TITLE
Expose seed and cell vertex lists from hex lattice generator

### DIFF
--- a/design_api/services/voronoi_gen/voronoi_gen.py
+++ b/design_api/services/voronoi_gen/voronoi_gen.py
@@ -319,7 +319,12 @@ def build_hex_lattice(
     **cell_kwargs: Any,
 ) -> Union[
     Tuple[List[Tuple[float, float, float]], List[Tuple[int, int]]],
-    Tuple[List[Tuple[float, float, float]], List[Tuple[int, int]], Any],
+    Tuple[
+        List[Tuple[float, float, float]],
+        List[Tuple[float, float, float]],
+        List[Tuple[int, int]],
+        Any,
+    ],
 ]:
     """
     Generate a 3D hexagonally-packed lattice of points within the given AABB,
@@ -334,7 +339,10 @@ def build_hex_lattice(
     :func:`organic.construct_voronoi_cells`, or ``"uniform"`` to invoke
     :func:`uniform.compute_uniform_cells`. Additional keyword arguments are
     forwarded to the selected function. When ``mode`` is ``"uniform"``, the
-    returned cells are a mapping from seed indices to vertex arrays.
+    returned cells are a mapping from seed indices to vertex arrays.  The
+    return signature is ``(pts, cell_vertices, edges, cells)`` where ``pts`` are
+    the seed coordinates and ``cell_vertices`` is the vertex list referenced by
+    ``edges``.
     """
     # Unpack bounds
     x0, y0, z0 = bbox_min
@@ -438,7 +446,7 @@ def build_hex_lattice(
 
             # Reconstruct the reconciled vertex list in the same order used
             # when computing ``edge_list`` so edge indices remain valid.
-            verts = [
+            cell_vertices = [
                 tuple(map(float, xyz))
                 for idx in sorted(cells.keys())
                 for xyz in cells[idx]
@@ -450,7 +458,8 @@ def build_hex_lattice(
             cells = construct_voronoi_cells(
                 pts, bbox_min, bbox_max, **cell_kwargs
             )
-        return verts, edge_list, cells
+            cell_vertices = verts
+        return pts, cell_vertices, edge_list, cells
 
     # Ensure edges are bidirectional
     edge_list = edge_list + [(j, i) for i, j in edge_list]

--- a/tests/design_api/test_build_hex_lattice.py
+++ b/tests/design_api/test_build_hex_lattice.py
@@ -6,7 +6,7 @@ def test_build_hex_lattice_returns_cells():
     spacing = 0.5
     primitive = {"sphere": {"radius": 1.0}}
 
-    pts, edges, cells = build_hex_lattice(
+    seed_pts, cell_vertices, edges, cells = build_hex_lattice(
         bbox_min,
         bbox_max,
         spacing,
@@ -18,7 +18,8 @@ def test_build_hex_lattice_returns_cells():
     )
 
     # Expect some Voronoi vertices and connecting edges
-    assert pts and edges
+    assert cell_vertices and edges
+    assert seed_pts
     # Returned cells should contain SDF grids describing each seed cell
     assert cells and all("sdf" in cell for cell in cells)
 

--- a/tests/design_api/test_uniform_auto_mesh.py
+++ b/tests/design_api/test_uniform_auto_mesh.py
@@ -11,7 +11,7 @@ def test_uniform_lattice_autogenerates_mesh():
     primitive = {"sphere": {"radius": 1.0}}
 
     imds_mesh = primitive_to_imds_mesh(primitive)
-    pts, edges, cells = build_hex_lattice(
+    seed_pts, cell_vertices, edges, cells = build_hex_lattice(
         bbox_min,
         bbox_max,
         spacing,
@@ -23,7 +23,7 @@ def test_uniform_lattice_autogenerates_mesh():
         imds_mesh=imds_mesh,
     )
 
-    assert pts and cells
+    assert seed_pts and cell_vertices and cells
     first = next(iter(cells.values()))
     assert isinstance(first, np.ndarray)
     assert first.shape == (6, 3)


### PR DESCRIPTION
## Summary
- Return both seed points and cell vertex list from `build_hex_lattice` when generating Voronoi cells
- Preserve seed points in API response and expose cell vertices separately
- Drop large seed/cell vertex data from request logs

## Testing
- `pytest tests/design_api/test_build_hex_lattice.py tests/design_api/test_uniform_auto_mesh.py tests/design_api/test_hex_lattice_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_68abca4f51a48326bd0dc07ce4e5ddcf