### PR TITLE
Use snake_case bbox fields only

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -210,6 +210,11 @@ def _build_modifier_dict(raw_spec: dict) -> dict:
     # nested infill
     if isinstance(raw_spec.get('infill'), dict):
         infill_data.update(raw_spec['infill'])
+    # Normalize bounding box keys to snake_case if they slipped through
+    if 'bboxMin' in infill_data:
+        infill_data['bbox_min'] = infill_data.pop('bboxMin')
+    if 'bboxMax' in infill_data:
+        infill_data['bbox_max'] = infill_data.pop('bboxMax')
     # flattened fields
     if 'infill_pattern' in raw_spec:
         infill_data['pattern'] = raw_spec.pop('infill_pattern')

--- a/design_api/main.py
+++ b/design_api/main.py
@@ -125,8 +125,8 @@ async def review(req: dict, sid: Optional[str] = None):
         for node in spec:
             inf = node.get("modifiers", {}).get("infill", {})
             pts = inf.get("seed_points")
-            bbox_min = inf.get("bbox_min") or inf.get("bboxMin")
-            bbox_max = inf.get("bbox_max") or inf.get("bboxMax")
+            bbox_min = inf.get("bbox_min")
+            bbox_max = inf.get("bbox_max")
             logging.debug(f"pts {pts} bbox_min {bbox_min} bbox_max {bbox_max}")
 
             if pts and bbox_min and bbox_max:
@@ -224,8 +224,8 @@ async def update(req: UpdateRequest):
     for node in new_spec:
         inf = node.get("modifiers", {}).get("infill", {})
         pts = inf.get("seed_points")
-        bbox_min = inf.get("bbox_min") or inf.get("bboxMin")
-        bbox_max = inf.get("bbox_max") or inf.get("bboxMax")
+        bbox_min = inf.get("bbox_min")
+        bbox_max = inf.get("bbox_max")
         if pts and bbox_min and bbox_max:
             pattern = inf.get("pattern")
             if pattern == "voronoi":

--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -48,16 +48,16 @@ def generate_voronoi(spec: Dict[str, Any]) -> Dict[str, Any]:
         "seed_points": pts,
         "edges": edge_list,
         "cells": spec.get("cells"),
-        "bbox_min": spec.get("bbox_min") or spec.get("bboxMin"),
-        "bbox_max": spec.get("bbox_max") or spec.get("bboxMax"),
+        "bbox_min": spec.get("bbox_min"),
+        "bbox_max": spec.get("bbox_max"),
     }
 
 
 def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
     """Generate a hexagonal lattice for the given spec and return adjacency."""
 
-    bbox_min = spec.get("bbox_min") or spec.get("bboxMin")
-    bbox_max = spec.get("bbox_max") or spec.get("bboxMax")
+    bbox_min = spec.get("bbox_min")
+    bbox_max = spec.get("bbox_max")
     spacing = spec.get("spacing") or spec.get("min_dist") or 2.0
     primitive = spec.get("primitive", {})
     mode = spec.get("mode", "uniform")
@@ -73,9 +73,7 @@ def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
         "plane_normal",
         "max_distance",
         "bbox_min",
-        "bboxMax",
         "bbox_max",
-        "bboxMin",
         "seed_points",
         "use_voronoi_edges",
 

--- a/design_api/services/mapping.py
+++ b/design_api/services/mapping.py
@@ -79,6 +79,8 @@ def map_primitive(node: dict) -> dict:
     if 'infill' in modifiers:
         logger.debug(f"Applying infill with params: {modifiers.get('infill')}")
         infill_params = modifiers['infill']
+        if 'bboxMin' in infill_params or 'bboxMax' in infill_params:
+            raise SomeMappingError("Bounding box keys must use snake_case (bbox_min/bbox_max)")
         root = {
             "booleanOp": {"intersection": {}},
             "children": [

--- a/design_api/services/validator.py
+++ b/design_api/services/validator.py
@@ -1,6 +1,7 @@
 from ai_adapter.schema.implicitus_pb2 import Model
-from google.protobuf.json_format import ParseDict, MessageToDict
+from google.protobuf.json_format import ParseDict, MessageToDict, ParseError
 from google.protobuf.message import DecodeError
+import re
 
 class ValidationError(Exception):
     """Raised when the JSON spec cannot be parsed into the protobuf schema."""
@@ -19,10 +20,22 @@ def validate_model_spec(spec_dict: dict) -> Model:
     Raises:
         ValidationError: If the JSON does not match the protobuf schema.
     """
+    def _ensure_snake_case(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if re.search(r"[A-Z]", k):
+                    raise ValidationError(f"Mixed-case key detected: {k}")
+                _ensure_snake_case(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _ensure_snake_case(item)
+
+    _ensure_snake_case(spec_dict)
+
     model = Model()
     try:
         # ParseDict will perform field-level validation
         ParseDict(spec_dict, model, ignore_unknown_fields=False)
-    except (TypeError, DecodeError, ValueError) as e:
+    except (TypeError, DecodeError, ValueError, ParseError) as e:
         raise ValidationError(f"Failed to validate model spec: {e}")
     return model

--- a/tests/design_api/test_validator.py
+++ b/tests/design_api/test_validator.py
@@ -17,3 +17,17 @@ def test_validate_missing_root():
         assert hasattr(msg, 'root')
     except ValidationError:
         pytest.skip("Missing root raises ValidationError")
+
+
+def test_rejects_mixed_case_keys():
+    spec = map_primitive({"shape": "sphere", "size_mm": 10})
+    spec["root"]["bboxMin"] = [0, 0, 0]
+    with pytest.raises(ValidationError):
+        validate_model_spec(spec)
+
+
+def test_rejects_unknown_keys():
+    spec = map_primitive({"shape": "sphere", "size_mm": 10})
+    spec["root"]["unknown_field"] = 123
+    with pytest.raises(ValidationError):
+        validate_model_spec(spec)


### PR DESCRIPTION
## Summary
- Normalize infill bbox keys to `bbox_min`/`bbox_max`
- Remove camelCase bbox handling from design API and validator
- Reject mixed-case bbox keys during mapping
- Add validator tests for unknown and mixed-case keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3c43bec48326b8fc2f454ba9ebd5