### PR TITLE
test: add design API integration for VoronoiCanvas

### DIFF
--- a/implicitus-ui/tests/design_api_integration.test.tsx
+++ b/implicitus-ui/tests/design_api_integration.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import VoronoiCanvas from '../src/components/VoronoiCanvas';
+import { spawn, ChildProcess } from 'child_process';
+import path from 'path';
+// Polyfill ResizeObserver for Three.js
+(globalThis as any).ResizeObserver = class {
+  observe(){}
+  unobserve(){}
+  disconnect(){}
+};
+
+
+let server: ChildProcess | undefined;
+
+beforeAll(async () => {
+  const serverPath = path.join(__dirname, 'start_design_api.py');
+  server = spawn('python', [serverPath], { stdio: 'ignore' });
+  // wait until server is responsive
+  for (let i = 0; i < 50; i++) {
+    try {
+      const res = await fetch('http://127.0.0.1:8001/docs');
+      if (res.ok) return;
+    } catch (err) {
+      // ignore until ready
+    }
+    await new Promise(r => setTimeout(r, 100));
+  }
+  throw new Error('design_api server did not start');
+}, 10000);
+
+afterAll(() => {
+  server?.kill();
+});
+
+describe('design_api integration with VoronoiCanvas', () => {
+  it('renders without warning when backend provides edges', async () => {
+    const reqBody = {
+      primitives: [
+        {
+          shape: 'box',
+          size_mm: 10,
+          infill: {
+            pattern: 'voronoi',
+            mode: 'organic',
+            uniform: false,
+            min_dist: 2,
+            seed_points: [
+              [0, 0, 0],
+              [1, 0, 0],
+              [0, 1, 0],
+              [0, 0, 1],
+            ],
+            bbox_min: [0, 0, 0],
+            bbox_max: [1, 1, 1],
+          },
+        },
+      ],
+    };
+
+    const resp = await fetch('http://127.0.0.1:8001/design/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reqBody),
+    });
+    expect(resp.ok).toBe(true);
+    const body = await resp.json();
+    const infill = body.spec[0].modifiers.infill;
+    expect(infill.edges.length).toBeGreaterThan(0);
+
+    render(
+      <VoronoiCanvas
+        seedPoints={infill.seed_points}
+        edges={infill.edges}
+        bbox={[0, 0, 0, 1, 1, 1]}
+      />
+    );
+    expect(screen.queryByTestId('no-edges-warning')).toBeNull();
+  });
+});

--- a/implicitus-ui/tests/start_design_api.py
+++ b/implicitus-ui/tests/start_design_api.py
@@ -1,0 +1,25 @@
+import os, sys, types
+# ensure project root on path
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+# stub transformers
+transformers_stub = types.ModuleType('transformers')
+
+def pipeline(*args, **kwargs):
+    raise RuntimeError('pipeline should not be called in tests')
+
+class AutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+transformers_stub.pipeline = pipeline
+transformers_stub.AutoTokenizer = AutoTokenizer
+sys.modules['transformers'] = transformers_stub
+
+from design_api.main import app
+import uvicorn
+
+if __name__ == '__main__':
+    uvicorn.run(app, host='127.0.0.1', port=8001, log_level='warning')


### PR DESCRIPTION
## Summary
- add integration test hitting FastAPI `/design/review` endpoint and rendering `<VoronoiCanvas>`
- stub `transformers` to launch API for tests

## Testing
- `npm --prefix implicitus-ui test`
- `pytest tests/design_api/test_api.py::test_design_happy -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4dcddb1c8326a0f0e139ce9edbb6