### PR TITLE
Prototype Voronoi mesh API and UI integration

### DIFF
--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -31,4 +31,26 @@ pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {
     f64::MAX
 }
 
+/// Simple mesh structure containing explicit vertices and edge indices.
+pub struct VoronoiMesh {
+    pub vertices: Vec<(f64, f64, f64)>,
+    pub edges: Vec<(usize, usize)>,
+}
+
+/// Prototype Voronoi mesher.
+///
+/// For now this merely echoes the seed points as vertices and links them in a
+/// ring.  It provides a stand‑in API for downstream consumers.
+pub fn voronoi_mesh(seeds: &[(f64, f64, f64)]) -> VoronoiMesh {
+    let vertices = seeds.to_vec();
+    let mut edges = Vec::new();
+    if seeds.len() > 1 {
+        for i in 0..seeds.len() {
+            let j = (i + 1) % seeds.len();
+            edges.push((i, j));
+        }
+    }
+    VoronoiMesh { vertices, edges }
+}
+
 pub mod slice;

--- a/core_engine/tests/voronoi_mesh.rs
+++ b/core_engine/tests/voronoi_mesh.rs
@@ -1,0 +1,9 @@
+use core_engine::voronoi_mesh;
+
+#[test]
+fn triangle_mesh_edges() {
+    let seeds = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)];
+    let mesh = voronoi_mesh(&seeds);
+    assert_eq!(mesh.vertices.len(), 3);
+    assert_eq!(mesh.edges, vec![(0,1),(1,2),(2,0)]);
+}

--- a/docs/mesh_generation.md
+++ b/docs/mesh_generation.md
@@ -1,0 +1,23 @@
+# Mesh Generation Roadmap
+
+This document outlines how the `core_engine` will evolve to produce meshes for
+both primitive solids and infill structures.
+
+## Primitives
+
+* Parse the `implicitus` model tree and evaluate SDFs for each primitive.
+* Convert SDF surfaces into triangle meshes using marching cubes or similar
+  algorithms.
+* Return vertex and edge lists that other subsystems can consume directly.
+
+## Infills
+
+* Accept seed points and bounds describing the infill region.
+* Construct Voronoi or lattice cells, yielding explicit vertex coordinates.
+* Produce edge connectivity so downstream tools can build struts or surfaces.
+
+## Unified Output
+
+The long‑term goal is to have `core_engine` provide a single authoritative
+geometry source.  Both the slicing API and the front‑end UI will consume the
+meshes generated here rather than duplicating meshing logic elsewhere.


### PR DESCRIPTION
## Summary
- outline future mesh generation steps in docs
- add `voronoi_mesh` prototype and expose via server endpoint
- fetch mesh from core engine in UI for single geometry source

## Testing
- `cargo test`
- `npm test --prefix implicitus-ui` *(fails: design_api server did not start)*

------
https://chatgpt.com/codex/tasks/task_e_68ae52c676448326b277633d2e4a8bef