### PR TITLE
Deserialize models in slicer server

### DIFF
--- a/core_engine/build.rs
+++ b/core_engine/build.rs
@@ -5,6 +5,15 @@ fn main() {
     let proto_dir = manifest_dir.parent().unwrap().join("schema");
     let proto_file = proto_dir.join("implicitus.proto");
 
-    prost_build::compile_protos(&[proto_file], &[proto_dir])
+    let mut config = prost_build::Config::new();
+    // Derive Serialize/Deserialize for all generated types so we can
+    // convert JSON models directly into protobuf structs.
+    config.type_attribute(
+        ".",
+        "#[derive(serde::Serialize, serde::Deserialize)]",
+    );
+
+    config
+        .compile_protos(&[proto_file], &[proto_dir])
         .expect("Failed to compile protobufs");
 }

--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -1,8 +1,6 @@
 // core_engine/src/bin/slicer_server.rs
 
-use core_engine::implicitus::node::Body;
-use core_engine::implicitus::primitive::Shape;
-use core_engine::implicitus::{Model, Node, Primitive, Sphere};
+use core_engine::implicitus::Model;
 use core_engine::slice::{slice_model, SliceConfig};
 use core_engine::voronoi_mesh;
 use serde::{Deserialize, Serialize};
@@ -11,22 +9,22 @@ use warp::http::Method;
 use warp::Filter;
 
 #[derive(Deserialize)]
-struct SliceRequest {
+pub struct SliceRequest {
     // TODO: replace Value with actual Model once JSON <-> Protobuf integration is set up
     #[serde(rename = "model")]
-    _model: Value,
-    layer: f64,
-    x_min: Option<f64>,
-    x_max: Option<f64>,
-    y_min: Option<f64>,
-    y_max: Option<f64>,
-    nx: Option<usize>,
-    ny: Option<usize>,
+    pub _model: Value,
+    pub layer: f64,
+    pub x_min: Option<f64>,
+    pub x_max: Option<f64>,
+    pub y_min: Option<f64>,
+    pub y_max: Option<f64>,
+    pub nx: Option<usize>,
+    pub ny: Option<usize>,
 }
 
-#[derive(Serialize)]
-struct SliceResponse {
-    contours: Vec<Vec<(f64, f64)>>,
+#[derive(Serialize, Deserialize)]
+pub struct SliceResponse {
+    pub contours: Vec<Vec<(f64, f64)>>,
 }
 
 #[derive(Deserialize)]
@@ -64,19 +62,14 @@ async fn main() {
     warp::serve(routes).run(([127, 0, 0, 1], 4000)).await;
 }
 
-async fn handle_slice(req: SliceRequest) -> Result<impl warp::Reply, warp::Rejection> {
-    // TODO: Deserialize Value into Model with proper JSON->Protobuf conversion.
-    // For now, construct a dummy sphere model based on the prompt in req.model.
-    let mut model = Model::default();
-    model.id = "dummy".into();
+#[derive(Debug)]
+struct InvalidModel;
+impl warp::reject::Reject for InvalidModel {}
 
-    let mut prim = Primitive::default();
-    let sphere = Sphere { radius: 1.0 };
-    prim.shape = Some(Shape::Sphere(sphere));
-
-    let mut root = Node::default();
-    root.body = Some(Body::Primitive(prim));
-    model.root = Some(root);
+pub async fn handle_slice(req: SliceRequest) -> Result<impl warp::Reply, warp::Rejection> {
+    // Deserialize the incoming model description.
+    let model: Model = serde_json::from_value(req._model)
+        .map_err(|_| warp::reject::custom(InvalidModel))?;
 
     let config = SliceConfig {
         z: req.layer,

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -9,7 +9,7 @@ use implicitus::Model;
 use implicitus::node::Body;
 use implicitus::primitive::Shape;
 
-// A very basic SDF evaluator that only handles a single sphere at the root.
+// A very basic SDF evaluator that handles a few primitive shapes.
 pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {
     // Check for a root node
     if let Some(root_node) = &model.root {
@@ -22,7 +22,24 @@ pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {
                         let dist = (x*x + y*y + z*z).sqrt();
                         return dist - s.radius;
                     }
-                    _ => {},
+                    Shape::Box(b) => {
+                        // Axis-aligned box centered at the origin
+                        if let Some(size) = &b.size {
+                            let hx = size.x / 2.0;
+                            let hy = size.y / 2.0;
+                            let hz = size.z / 2.0;
+                            let qx = x.abs() - hx;
+                            let qy = y.abs() - hy;
+                            let qz = z.abs() - hz;
+                            let outside = (qx.max(0.0).powi(2)
+                                + qy.max(0.0).powi(2)
+                                + qz.max(0.0).powi(2))
+                                .sqrt();
+                            let inside = qx.max(qy.max(qz)).min(0.0);
+                            return outside + inside;
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/core_engine/tests/box_slice.rs
+++ b/core_engine/tests/box_slice.rs
@@ -1,0 +1,51 @@
+#[path = "../src/bin/slicer_server.rs"]
+mod slicer_server;
+
+use slicer_server::{handle_slice, SliceRequest, SliceResponse};
+use core_engine::implicitus::{Model, Node, Primitive, Vector3, primitive::Shape, node::Body, Box};
+use serde_json::to_value;
+use warp::hyper::body::to_bytes;
+use warp::Reply;
+
+#[tokio::test]
+async fn slice_box_model_returns_square_contour() {
+    // Build a simple box model centered at the origin with side length 2.0
+    let mut model = Model::default();
+    model.id = "box".into();
+
+    let box_shape = Box { size: Some(Vector3 { x: 2.0, y: 2.0, z: 2.0 }) };
+    let mut prim = Primitive::default();
+    prim.shape = Some(Shape::Box(box_shape));
+
+    let mut node = Node::default();
+    node.body = Some(Body::Primitive(prim));
+    model.root = Some(node);
+
+    let req = SliceRequest {
+        _model: to_value(&model).unwrap(),
+        layer: 0.0,
+        x_min: Some(-1.5),
+        x_max: Some(1.5),
+        y_min: Some(-1.5),
+        y_max: Some(1.5),
+        nx: Some(5),
+        ny: Some(5),
+    };
+
+    let reply = handle_slice(req).await.unwrap();
+    let body = reply.into_response().into_body();
+    let bytes = to_bytes(body).await.unwrap();
+    let resp: SliceResponse = serde_json::from_slice(&bytes).unwrap();
+    let contour = &resp.contours[0];
+
+    // Verify contour bounds match the box dimensions
+    let min_x = contour.iter().map(|p| p.0).fold(f64::INFINITY, f64::min);
+    let max_x = contour.iter().map(|p| p.0).fold(f64::NEG_INFINITY, f64::max);
+    let min_y = contour.iter().map(|p| p.1).fold(f64::INFINITY, f64::min);
+    let max_y = contour.iter().map(|p| p.1).fold(f64::NEG_INFINITY, f64::max);
+
+    assert!((min_x + 1.0).abs() < 1e-6, "min_x was {}", min_x);
+    assert!((max_x - 1.0).abs() < 1e-6, "max_x was {}", max_x);
+    assert!((min_y + 1.0).abs() < 1e-6, "min_y was {}", min_y);
+    assert!((max_y - 1.0).abs() < 1e-6, "max_y was {}", max_y);
+}


### PR DESCRIPTION
## Summary
- derive serde traits for protobuf types to accept JSON models
- deserialize incoming model in slicer server and use real geometry
- support box SDFs and test slicing a box

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7a992d748326b56a77a766ac3340