### PR TITLE
Add deterministic Rust primitive sampler and Python wrapper

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -5,14 +5,13 @@ from google.protobuf.json_format import ParseDict
 from ai_adapter.schema.implicitus_pb2 import Model
 import uuid
 from google.protobuf import json_format
-from design_api.services.voronoi_gen.organic.sampler import sample_seed_points
+from ai_adapter import rust_primitives
 
 # Maximum number of voronoi seed points to avoid huge arrays
 MAX_SEED_POINTS = 7500
 
 # --- Helper functions for voronoi seed generation ---
 import random
-import numpy as np
 
 def _parse_bool(value):
     """Robustly interpret a JSON boolean that may arrive as a string."""
@@ -21,92 +20,6 @@ def _parse_bool(value):
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
-
-def _auto_generate_seed_points(
-    shape: str,
-    params: dict,
-    bbox_min: tuple,
-    bbox_max: tuple,
-    spacing: float,
-    uniform: bool = False,
-    grid_resolution: tuple = (32, 32, 32)
-) -> list:
-    """
-    Generate seed points inside the given primitive shape within its AABB,
-    using either a uniform grid or Poisson-disk/grid-jitter at the given spacing.
-    """
-    if uniform:
-        # uniform grid at the given spacing + shape rejection
-        nx = int((bbox_max[0] - bbox_min[0]) / spacing) + 1
-        ny = int((bbox_max[1] - bbox_min[1]) / spacing) + 1
-        nz = int((bbox_max[2] - bbox_min[2]) / spacing) + 1
-        xs = [bbox_min[0] + i * spacing for i in range(nx)]
-        ys = [bbox_min[1] + j * spacing for j in range(ny)]
-        zs = [bbox_min[2] + k * spacing for k in range(nz)]
-        raw_seeds = []
-        for x in xs:
-            for y in ys:
-                for z in zs:
-                    raw_seeds.append([x, y, z])
-    else:
-        try:
-            raw_seeds = sample_seed_points(
-                num_points=MAX_SEED_POINTS,
-                bbox_min=bbox_min,
-                bbox_max=bbox_max,
-                min_dist=spacing
-            )
-        except Exception as e:
-            logging.debug(f"_auto_generate_seed_points: Poisson-disk sampling failed, falling back to grid jitter: {e}")
-            raw_seeds = []
-            nx = int((bbox_max[0] - bbox_min[0]) / spacing) + 1
-            ny = int((bbox_max[1] - bbox_min[1]) / spacing) + 1
-            nz = int((bbox_max[2] - bbox_min[2]) / spacing) + 1
-            for i in range(nx):
-                for j in range(ny):
-                    for k in range(nz):
-                        x = bbox_min[0] + i * spacing + (random.random() - 0.5) * spacing
-                        y = bbox_min[1] + j * spacing + (random.random() - 0.5) * spacing
-                        z = bbox_min[2] + k * spacing + (random.random() - 0.5) * spacing
-                        raw_seeds.append([x, y, z])
-    # Reject any points outside the exact primitive volume
-    seeds = [pt for pt in raw_seeds if _point_inside_shape(shape, params, tuple(pt))]
-    logging.debug(
-        f"_auto_generate_seed_points: shape={shape}, spacing={spacing}, "
-        f"bbox_min={bbox_min}, bbox_max={bbox_max}, sampled={len(raw_seeds)}, after_rejection={len(seeds)}"
-    )
-    # Cap seed list to avoid excessive points
-    if len(seeds) > MAX_SEED_POINTS:
-        random.shuffle(seeds)
-        seeds = seeds[:MAX_SEED_POINTS]
-        logging.debug(f"_auto_generate_seed_points: capped seed count to {len(seeds)}")
-    return seeds
-
-def _point_inside_shape(shape: str, params: dict, pt: tuple) -> bool:
-    """
-    Check if point pt is inside the primitive defined by shape and params.
-    """
-    x, y, z = pt
-    if shape == 'sphere':
-        r = params.get('radius', params.get('radius_mm', 0))
-        return (x*x + y*y + z*z) <= r*r
-    if shape in ('cube', 'box'):
-        # size may be dict or scalar
-        size = params.get('size')
-        if isinstance(size, dict):
-            sx, sy, sz = size.get('x',0)/2, size.get('y',0)/2, size.get('z',0)/2
-        else:
-            half = size/2
-            sx = sy = sz = half
-        return abs(x) <= sx and abs(y) <= sy and abs(z) <= sz
-    if shape == 'cylinder':
-        r = params.get('radius', params.get('radius_mm',0))
-        h = params.get('height', params.get('height_mm',0))
-        inside_circle = (x*x + y*y) <= r*r
-        return inside_circle and (0 <= z <= h)
-    # default: accept
-    return True
-
 
 import logging
 logging.basicConfig(level=logging.DEBUG)
@@ -441,27 +354,25 @@ def interpret_llm_request(llm_output):
                 # surface uniform‐sampling toggle in spec
                 infill.setdefault('uniform', True)
                 # Auto-generate seed points inside the primitive if missing
-                shape, params = next(iter(node['primitive'].items()))
+                shape, _params = next(iter(node['primitive'].items()))
                 if 'seed_points' not in infill:
-                    # include uniform/resolution flags in update branch
                     uniform = _parse_bool(infill.get('uniform', True))
-                    resolution = tuple(infill.get('resolution', [32, 32, 32]))
-                    logging.debug(f"interpret_llm_request update-branch: uniform sampling={uniform}, resolution={resolution}")
-                    seeds = _auto_generate_seed_points(
-                        shape, params, bbox_min, bbox_max,
-                        infill['min_dist'],
-                        uniform=uniform,
-                        grid_resolution=resolution
+                    infill['uniform'] = uniform
+                    logging.debug(
+                        f"interpret_llm_request update-branch: uniform sampling={uniform}"
                     )
-                    # Set num_points default if not present
+                    seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+                    if len(seeds) > MAX_SEED_POINTS:
+                        seeds = seeds[:MAX_SEED_POINTS]
                     infill.setdefault('num_points', len(seeds))
-                    # if user specified a desired count, trim to that many
                     if 'num_points' in infill:
                         import random
                         random.shuffle(seeds)
                         seeds = seeds[: int(infill['num_points'])]
                     infill['seed_points'] = seeds
-                    logging.debug(f"interpret_llm_request: generated {len(seeds)} seed points for {shape}")
+                    logging.debug(
+                        f"interpret_llm_request: generated {len(seeds)} seed points for {shape}"
+                    )
         return {"primitives": nodes}
     else:
         raw = llm_output
@@ -521,24 +432,24 @@ def interpret_llm_request(llm_output):
             infill.setdefault('uniform', True)
             # Also support uniform/resolution for auto seed generation if seed_points missing
             if 'seed_points' not in infill:
-                shape, params = next(iter(node['primitive'].items()))
-                # include uniform/resolution flags in update branch
+                shape, _params = next(iter(node['primitive'].items()))
                 uniform = _parse_bool(infill.get('uniform', True))
-                resolution = tuple(infill.get('resolution', [32, 32, 32]))
-                logging.debug(f"interpret_llm_request update-branch: uniform sampling={uniform}, resolution={resolution}")
-                seeds = _auto_generate_seed_points(
-                    shape, params, bbox_min, bbox_max,
-                    infill['min_dist'],
-                    uniform=uniform,
-                    grid_resolution=resolution
+                infill['uniform'] = uniform
+                logging.debug(
+                    f"interpret_llm_request update-branch: uniform sampling={uniform}"
                 )
+                seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+                if len(seeds) > MAX_SEED_POINTS:
+                    seeds = seeds[:MAX_SEED_POINTS]
                 infill.setdefault('num_points', len(seeds))
                 if 'num_points' in infill:
                     import random
                     random.shuffle(seeds)
                     seeds = seeds[: int(infill['num_points'])]
                 infill['seed_points'] = seeds
-                logging.debug(f"interpret_llm_request: generated {len(seeds)} seed points for {shape}")
+                logging.debug(
+                    f"interpret_llm_request: generated {len(seeds)} seed points for {shape}"
+                )
     return {"primitives": nodes}
 
 def build_model_from_spec(nodes, boolean_op=None):
@@ -760,12 +671,10 @@ def update_request(sid: str, spec: list, raw: str):
             infill.setdefault('auto_cap', False)
             # always regenerate seed points, and expose num_points parameter
             uniform = _parse_bool(infill.get('uniform', True))
-            resolution = tuple(infill.get('resolution', [32, 32, 32]))
-            seeds = _auto_generate_seed_points(
-                shape, params, bbox_min, bbox_max,
-                infill['min_dist'], uniform=uniform,
-                grid_resolution=resolution
-            )
+            infill['uniform'] = uniform
+            seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+            if len(seeds) > MAX_SEED_POINTS:
+                seeds = seeds[:MAX_SEED_POINTS]
             # expose a tunable count parameter for seed generation
             infill.setdefault('num_points', len(seeds))
             if 'num_points' in infill:

--- a/ai_adapter/rust_primitives.py
+++ b/ai_adapter/rust_primitives.py
@@ -1,0 +1,58 @@
+"""Python bindings for Rust primitive sampling functions.
+
+This module loads the ``core_engine`` Rust extension on demand without
+triggering heavy design API imports.  It mirrors the loader used by the
+``design_api`` package but lives here to avoid a circular import that caused
+startup failures when the extension wasn't yet available.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+from types import ModuleType
+
+
+def _load_core_engine() -> ModuleType:
+    """Import the compiled ``core_engine`` module, building it if needed."""
+
+    spec = importlib.util.find_spec("core_engine.core_engine")
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    crate_dir = pathlib.Path(__file__).resolve().parents[1] / "core_engine"
+    env = os.environ.copy()
+    env.setdefault("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+    subprocess.run(["cargo", "build"], cwd=crate_dir, env=env, check=True)
+
+    if sys.platform.startswith("win"):
+        lib_name = "core_engine.dll"
+    elif sys.platform == "darwin":
+        lib_name = "libcore_engine.dylib"
+    else:
+        lib_name = "libcore_engine.so"
+
+    lib_path = crate_dir / "target" / "debug" / lib_name
+    loader = importlib.machinery.ExtensionFileLoader(
+        "core_engine.core_engine", str(lib_path)
+    )
+    spec = importlib.util.spec_from_loader("core_engine.core_engine", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+_core = _load_core_engine()
+_sample_inside_rust = _core.sample_inside
+
+
+def sample_inside(shape_spec, spacing):
+    """Return seed points inside the given primitive at the specified spacing."""
+
+    return _sample_inside_rust(shape_spec, spacing)

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -10,6 +10,7 @@ use implicitus::node::Body;
 use implicitus::primitive::Shape;
 pub mod voronoi;
 pub mod uniform;
+pub mod primitives;
 
 // A very basic SDF evaluator that handles a few primitive shapes.
 pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {
@@ -83,5 +84,6 @@ fn core_engine(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(voronoi::cells::construct_voronoi_cells, m)?)?;
     m.add_function(wrap_pyfunction!(voronoi::cells::construct_surface_voronoi_cells, m)?)?;
     m.add_function(wrap_pyfunction!(uniform::hex::compute_uniform_cells, m)?)?;
+    m.add_function(wrap_pyfunction!(primitives::sample_inside, m)?)?;
     Ok(())
 }

--- a/core_engine/src/primitives/mod.rs
+++ b/core_engine/src/primitives/mod.rs
@@ -1,0 +1,111 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+const MAX_SEED_POINTS: usize = 7500;
+
+fn get_f64(dict: &PyDict, key: &str) -> Option<f64> {
+    dict.get_item(key)
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<f64>().ok())
+}
+
+fn get_dict<'a>(dict: &'a PyDict, key: &str) -> Option<&'a PyDict> {
+    dict.get_item(key)
+        .ok()
+        .flatten()
+        .and_then(|v| v.downcast::<PyDict>().ok())
+}
+
+fn point_inside(shape: &str, params: &PyDict, x: f64, y: f64, z: f64) -> bool {
+    match shape {
+        "sphere" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            x * x + y * y + z * z <= r * r
+        }
+        "cube" | "box" => {
+            if let Some(size_dict) = get_dict(params, "size") {
+                let sx = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
+                let sy = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
+                let sz = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                x.abs() <= sx && y.abs() <= sy && z.abs() <= sz
+            } else if let Some(size_val) = get_f64(params, "size") {
+                let half = size_val / 2.0;
+                x.abs() <= half && y.abs() <= half && z.abs() <= half
+            } else {
+                true
+            }
+        }
+        "cylinder" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            let h = get_f64(params, "height").unwrap_or(0.0);
+            x * x + y * y <= r * r && (0.0..=h).contains(&z)
+        }
+        _ => true,
+    }
+}
+
+fn bounding_box(shape: &str, params: &PyDict) -> ((f64, f64, f64), (f64, f64, f64)) {
+    match shape {
+        "box" => {
+            if let Some(size_dict) = get_dict(params, "size") {
+                let x = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
+                let y = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
+                let z = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                return ((-x, -y, -z), (x, y, z));
+            }
+        }
+        "cube" => {
+            if let Some(size_val) = get_f64(params, "size") {
+                let half = size_val / 2.0;
+                return ((-half, -half, -half), (half, half, half));
+            }
+        }
+        "sphere" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            return ((-r, -r, -r), (r, r, r));
+        }
+        "cylinder" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            let h = get_f64(params, "height").unwrap_or(0.0);
+            return ((-r, -r, 0.0), (r, r, h));
+        }
+        _ => {}
+    }
+    ((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+}
+
+#[pyfunction]
+pub fn sample_inside(shape_spec: &PyDict, spacing: f64) -> PyResult<Vec<(f64, f64, f64)>> {
+    if shape_spec.len() != 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "shape_spec must contain exactly one primitive",
+        ));
+    }
+    let (shape_name, params_any) = shape_spec.iter().next().unwrap();
+    let shape: String = shape_name.extract()?;
+    let params = params_any.downcast::<PyDict>()?;
+    let (bbox_min, bbox_max) = bounding_box(&shape, params);
+
+    let nx = ((bbox_max.0 - bbox_min.0) / spacing).floor() as usize + 1;
+    let ny = ((bbox_max.1 - bbox_min.1) / spacing).floor() as usize + 1;
+    let nz = ((bbox_max.2 - bbox_min.2) / spacing).floor() as usize + 1;
+
+    let mut seeds: Vec<(f64, f64, f64)> = Vec::new();
+    for ix in 0..nx {
+        let x = bbox_min.0 + ix as f64 * spacing;
+        for iy in 0..ny {
+            let y = bbox_min.1 + iy as f64 * spacing;
+            for iz in 0..nz {
+                let z = bbox_min.2 + iz as f64 * spacing;
+                if point_inside(&shape, params, x, y, z) {
+                    seeds.push((x, y, z));
+                    if seeds.len() >= MAX_SEED_POINTS {
+                        return Ok(seeds);
+                    }
+                }
+            }
+        }
+    }
+    Ok(seeds)
+}


### PR DESCRIPTION
## Summary
- expose `core_engine::primitives::sample_inside` for deterministic primitive seed generation
- wrap Rust sampler in `ai_adapter.rust_primitives` and use it in CSG adapter
- load `core_engine` directly in `rust_primitives` to avoid importing heavy design API modules during startup

## Testing
- `cargo test --lib`
- `cargo test` *(fails: linking with `cc` failed: undefined reference to `PySequence_Check` and other PyO3 symbols)*
- `pytest` *(fails: KeyError: 'design_api.services.voronoi_gen')*


------
https://chatgpt.com/codex/tasks/task_e_68af762aa32c8326a6f6d9bbdb8af5ef