### PR TITLE
Add deterministic Rust primitive sampler and Python wrapper

### DIFF
--- a/ai_adapter/rust_primitives.py
+++ b/ai_adapter/rust_primitives.py
@@ -1,0 +1,58 @@
+"""Python bindings for Rust primitive sampling functions.
+
+This module loads the ``core_engine`` Rust extension on demand without
+triggering heavy design API imports.  It mirrors the loader used by the
+``design_api`` package but lives here to avoid a circular import that caused
+startup failures when the extension wasn't yet available.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+from types import ModuleType
+
+
+def _load_core_engine() -> ModuleType:
+    """Import the compiled ``core_engine`` module, building it if needed."""
+
+    spec = importlib.util.find_spec("core_engine.core_engine")
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    crate_dir = pathlib.Path(__file__).resolve().parents[1] / "core_engine"
+    env = os.environ.copy()
+    env.setdefault("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+    subprocess.run(["cargo", "build"], cwd=crate_dir, env=env, check=True)
+
+    if sys.platform.startswith("win"):
+        lib_name = "core_engine.dll"
+    elif sys.platform == "darwin":
+        lib_name = "libcore_engine.dylib"
+    else:
+        lib_name = "libcore_engine.so"
+
+    lib_path = crate_dir / "target" / "debug" / lib_name
+    loader = importlib.machinery.ExtensionFileLoader(
+        "core_engine.core_engine", str(lib_path)
+    )
+    spec = importlib.util.spec_from_loader("core_engine.core_engine", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+_core = _load_core_engine()
+_sample_inside_rust = _core.sample_inside
+
+
+def sample_inside(shape_spec, spacing):
+    """Return seed points inside the given primitive at the specified spacing."""
+
+    return _sample_inside_rust(shape_spec, spacing)

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -10,6 +10,7 @@ use implicitus::node::Body;
 use implicitus::primitive::Shape;
 pub mod voronoi;
 pub mod uniform;
+pub mod primitives;
 
 // A very basic SDF evaluator that handles a few primitive shapes.
 pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {
@@ -83,5 +84,6 @@ fn core_engine(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(voronoi::cells::construct_voronoi_cells, m)?)?;
     m.add_function(wrap_pyfunction!(voronoi::cells::construct_surface_voronoi_cells, m)?)?;
     m.add_function(wrap_pyfunction!(uniform::hex::compute_uniform_cells, m)?)?;
+    m.add_function(wrap_pyfunction!(primitives::sample_inside, m)?)?;
     Ok(())
 }

--- a/core_engine/src/primitives/mod.rs
+++ b/core_engine/src/primitives/mod.rs
@@ -1,0 +1,111 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+const MAX_SEED_POINTS: usize = 7500;
+
+fn get_f64(dict: &PyDict, key: &str) -> Option<f64> {
+    dict.get_item(key)
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<f64>().ok())
+}
+
+fn get_dict<'a>(dict: &'a PyDict, key: &str) -> Option<&'a PyDict> {
+    dict.get_item(key)
+        .ok()
+        .flatten()
+        .and_then(|v| v.downcast::<PyDict>().ok())
+}
+
+fn point_inside(shape: &str, params: &PyDict, x: f64, y: f64, z: f64) -> bool {
+    match shape {
+        "sphere" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            x * x + y * y + z * z <= r * r
+        }
+        "cube" | "box" => {
+            if let Some(size_dict) = get_dict(params, "size") {
+                let sx = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
+                let sy = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
+                let sz = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                x.abs() <= sx && y.abs() <= sy && z.abs() <= sz
+            } else if let Some(size_val) = get_f64(params, "size") {
+                let half = size_val / 2.0;
+                x.abs() <= half && y.abs() <= half && z.abs() <= half
+            } else {
+                true
+            }
+        }
+        "cylinder" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            let h = get_f64(params, "height").unwrap_or(0.0);
+            x * x + y * y <= r * r && (0.0..=h).contains(&z)
+        }
+        _ => true,
+    }
+}
+
+fn bounding_box(shape: &str, params: &PyDict) -> ((f64, f64, f64), (f64, f64, f64)) {
+    match shape {
+        "box" => {
+            if let Some(size_dict) = get_dict(params, "size") {
+                let x = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
+                let y = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
+                let z = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                return ((-x, -y, -z), (x, y, z));
+            }
+        }
+        "cube" => {
+            if let Some(size_val) = get_f64(params, "size") {
+                let half = size_val / 2.0;
+                return ((-half, -half, -half), (half, half, half));
+            }
+        }
+        "sphere" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            return ((-r, -r, -r), (r, r, r));
+        }
+        "cylinder" => {
+            let r = get_f64(params, "radius").unwrap_or(0.0);
+            let h = get_f64(params, "height").unwrap_or(0.0);
+            return ((-r, -r, 0.0), (r, r, h));
+        }
+        _ => {}
+    }
+    ((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+}
+
+#[pyfunction]
+pub fn sample_inside(shape_spec: &PyDict, spacing: f64) -> PyResult<Vec<(f64, f64, f64)>> {
+    if shape_spec.len() != 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "shape_spec must contain exactly one primitive",
+        ));
+    }
+    let (shape_name, params_any) = shape_spec.iter().next().unwrap();
+    let shape: String = shape_name.extract()?;
+    let params = params_any.downcast::<PyDict>()?;
+    let (bbox_min, bbox_max) = bounding_box(&shape, params);
+
+    let nx = ((bbox_max.0 - bbox_min.0) / spacing).floor() as usize + 1;
+    let ny = ((bbox_max.1 - bbox_min.1) / spacing).floor() as usize + 1;
+    let nz = ((bbox_max.2 - bbox_min.2) / spacing).floor() as usize + 1;
+
+    let mut seeds: Vec<(f64, f64, f64)> = Vec::new();
+    for ix in 0..nx {
+        let x = bbox_min.0 + ix as f64 * spacing;
+        for iy in 0..ny {
+            let y = bbox_min.1 + iy as f64 * spacing;
+            for iz in 0..nz {
+                let z = bbox_min.2 + iz as f64 * spacing;
+                if point_inside(&shape, params, x, y, z) {
+                    seeds.push((x, y, z));
+                    if seeds.len() >= MAX_SEED_POINTS {
+                        return Ok(seeds);
+                    }
+                }
+            }
+        }
+    }
+    Ok(seeds)
+}


### PR DESCRIPTION
## Summary
- expose `core_engine::primitives::sample_inside` for deterministic primitive seed generation
- wrap Rust sampler in `ai_adapter.rust_primitives` and use it in CSG adapter
- load `core_engine` directly in `rust_primitives` to avoid importing heavy design API modules during startup
- lazy-load the inference pipeline so tests run without the `transformers` dependency

## Testing
- `cargo test --lib`
- `pytest tests/ai_adapter/test_csg_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68af762aa32c8326a6f6d9bbdb8af5ef