### PR TITLE
docs: clarify dev server setup

### DIFF
--- a/implicitus-ui/README.md
+++ b/implicitus-ui/README.md
@@ -3,6 +3,17 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Getting Started
+
+This UI requires **Node.js 18.18 or newer**. To launch the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+`npm run dev` starts the Vite server. Running `npm install dev` will try to install a package named `dev` which depends on the Linux-only `inotify` module and fails on macOS.
+
 ## Current Progress
 
 Our application now includes a full-featured Voronoi lattice generation backend with the following capabilities:

--- a/implicitus-ui/package.json
+++ b/implicitus-ui/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- document Node.js 18.18+ requirement for the UI
- explain to run `npm run dev` instead of installing the `dev` package
- declare Node engine version in package.json

## Testing
- `npm test` *(fails: design_api server did not start)*
- `npm run lint` *(fails: React Hooks called conditionally in VoronoiMesh.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68afa5dced6c8326858899a297fbbe9b