### PR TITLE
chore: upgrade pyo3 for python 3.13

### DIFF
--- a/ai_adapter/rust_primitives.py
+++ b/ai_adapter/rust_primitives.py
@@ -30,6 +30,7 @@ def _load_core_engine() -> ModuleType:
     crate_dir = pathlib.Path(__file__).resolve().parents[1] / "core_engine"
     env = os.environ.copy()
     env.setdefault("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+    env.setdefault("PYO3_PYTHON", sys.executable)
     subprocess.run(["cargo", "build"], cwd=crate_dir, env=env, check=True)
 
     if sys.platform.startswith("win"):

--- a/core_engine/Cargo.toml
+++ b/core_engine/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [build-dependencies]
 prost-build = "0.11"
-pyo3-build-config = { version = "0.21", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.22", features = ["resolve-config"] }
 
 [dependencies]
 prost = "0.11"
@@ -16,10 +16,10 @@ serde_json = "1.0"
 rand = "0.8"
 
 rayon = "1.8"
-numpy = "0.21"
-ndarray = "0.15"
+numpy = "0.22"
+ndarray = "0.16"
 
-pyo3 = { version = "0.21", features = ["abi3-py39"] }
+pyo3 = { version = "0.22", features = ["abi3-py39"] }
 
 [features]
 default = []

--- a/core_engine/src/primitives/mod.rs
+++ b/core_engine/src/primitives/mod.rs
@@ -1,25 +1,27 @@
 #![allow(deprecated)]
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyDictMethods};
 
 const MAX_SEED_POINTS: usize = 7500;
 
-fn get_f64(dict: &PyDict, key: &str) -> Option<f64> {
-    dict.get_item(key)
+fn get_f64(dict: &Bound<PyDict>, key: &str) -> Option<f64> {
+    dict
+        .get_item(key)
         .ok()
         .flatten()
         .and_then(|v| v.extract::<f64>().ok())
 }
 
-fn get_dict<'a>(dict: &'a PyDict, key: &str) -> Option<&'a PyDict> {
-    dict.get_item(key)
+fn get_dict<'py>(dict: &Bound<'py, PyDict>, key: &str) -> Option<Bound<'py, PyDict>> {
+    dict
+        .get_item(key)
         .ok()
         .flatten()
-        .and_then(|v| v.downcast::<PyDict>().ok())
+        .and_then(|v| v.downcast_into::<PyDict>().ok())
 }
 
-fn point_inside(shape: &str, params: &PyDict, x: f64, y: f64, z: f64) -> bool {
+fn point_inside(shape: &str, params: &Bound<PyDict>, x: f64, y: f64, z: f64) -> bool {
     match shape {
         "sphere" => {
             let r = get_f64(params, "radius").unwrap_or(0.0);
@@ -27,9 +29,9 @@ fn point_inside(shape: &str, params: &PyDict, x: f64, y: f64, z: f64) -> bool {
         }
         "cube" | "box" => {
             if let Some(size_dict) = get_dict(params, "size") {
-                let sx = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
-                let sy = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
-                let sz = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                let sx = get_f64(&size_dict, "x").unwrap_or(0.0) / 2.0;
+                let sy = get_f64(&size_dict, "y").unwrap_or(0.0) / 2.0;
+                let sz = get_f64(&size_dict, "z").unwrap_or(0.0) / 2.0;
                 x.abs() <= sx && y.abs() <= sy && z.abs() <= sz
             } else if let Some(size_val) = get_f64(params, "size") {
                 let half = size_val / 2.0;
@@ -47,13 +49,13 @@ fn point_inside(shape: &str, params: &PyDict, x: f64, y: f64, z: f64) -> bool {
     }
 }
 
-fn bounding_box(shape: &str, params: &PyDict) -> ((f64, f64, f64), (f64, f64, f64)) {
+fn bounding_box(shape: &str, params: &Bound<PyDict>) -> ((f64, f64, f64), (f64, f64, f64)) {
     match shape {
         "box" => {
             if let Some(size_dict) = get_dict(params, "size") {
-                let x = get_f64(size_dict, "x").unwrap_or(0.0) / 2.0;
-                let y = get_f64(size_dict, "y").unwrap_or(0.0) / 2.0;
-                let z = get_f64(size_dict, "z").unwrap_or(0.0) / 2.0;
+                let x = get_f64(&size_dict, "x").unwrap_or(0.0) / 2.0;
+                let y = get_f64(&size_dict, "y").unwrap_or(0.0) / 2.0;
+                let z = get_f64(&size_dict, "z").unwrap_or(0.0) / 2.0;
                 return ((-x, -y, -z), (x, y, z));
             }
         }
@@ -78,7 +80,7 @@ fn bounding_box(shape: &str, params: &PyDict) -> ((f64, f64, f64), (f64, f64, f6
 }
 
 #[pyfunction]
-pub fn sample_inside(shape_spec: &PyDict, spacing: f64) -> PyResult<Vec<(f64, f64, f64)>> {
+pub fn sample_inside(shape_spec: &Bound<PyDict>, spacing: f64) -> PyResult<Vec<(f64, f64, f64)>> {
     if shape_spec.len() != 1 {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "shape_spec must contain exactly one primitive",
@@ -87,7 +89,7 @@ pub fn sample_inside(shape_spec: &PyDict, spacing: f64) -> PyResult<Vec<(f64, f6
     let (shape_name, params_any) = shape_spec.iter().next().unwrap();
     let shape: String = shape_name.extract()?;
     let params = params_any.downcast::<PyDict>()?;
-    let (bbox_min, bbox_max) = bounding_box(&shape, params);
+    let (bbox_min, bbox_max) = bounding_box(&shape, &params);
 
     let nx = ((bbox_max.0 - bbox_min.0) / spacing).floor() as usize + 1;
     let ny = ((bbox_max.1 - bbox_min.1) / spacing).floor() as usize + 1;
@@ -100,7 +102,7 @@ pub fn sample_inside(shape_spec: &PyDict, spacing: f64) -> PyResult<Vec<(f64, f6
             let y = bbox_min.1 + iy as f64 * spacing;
             for iz in 0..nz {
                 let z = bbox_min.2 + iz as f64 * spacing;
-                if point_inside(&shape, params, x, y, z) {
+                if point_inside(&shape, &params, x, y, z) {
                     seeds.push((x, y, z));
                     if seeds.len() >= MAX_SEED_POINTS {
                         return Ok(seeds);

--- a/core_engine/src/voronoi/cells.rs
+++ b/core_engine/src/voronoi/cells.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use numpy::IntoPyArray;
-use ndarray::Array3;
+use numpy::{ndarray::Array3, PyArray3};
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::cmp::{min, max};
@@ -94,9 +93,10 @@ pub fn construct_voronoi_cells(
 
     let mut cells: Vec<PyObject> = Vec::new();
     for (ci, seed) in points.iter().enumerate() {
-        let arr = Array3::from_shape_vec((nx,ny,nz), grids[ci].clone())
-            .unwrap()
-            .into_pyarray_bound(py);
+        let arr = PyArray3::from_owned_array_bound(
+            py,
+            Array3::from_shape_vec((nx, ny, nz), grids[ci].clone()).unwrap(),
+        );
         let dict = PyDict::new_bound(py);
         dict.set_item("site", seed)?;
         dict.set_item("sdf", arr)?;
@@ -168,9 +168,10 @@ pub fn construct_surface_voronoi_cells(
 
     let mut cells: Vec<PyObject>=Vec::new();
     for (ci, seed) in points.iter().enumerate() {
-        let arr = Array3::from_shape_vec((nx,ny,nz), grids[ci].clone())
-            .unwrap()
-            .into_pyarray_bound(py);
+        let arr = PyArray3::from_owned_array_bound(
+            py,
+            Array3::from_shape_vec((nx, ny, nz), grids[ci].clone()).unwrap(),
+        );
         let dict = PyDict::new_bound(py);
         dict.set_item("site", seed)?;
         dict.set_item("sdf", arr)?;

--- a/design_api/services/voronoi_gen/organic/sampler.py
+++ b/design_api/services/voronoi_gen/organic/sampler.py
@@ -78,6 +78,7 @@ def _load_core_engine():
 
         env = os.environ.copy()
         env.setdefault("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+        env.setdefault("PYO3_PYTHON", sys.executable)
         subprocess.run(
             ["cargo", "build"],
             cwd=crate_dir,


### PR DESCRIPTION
## Summary
- upgrade `pyo3` and related crates for Python 3.13 compatibility
- adapt primitives module to new `Bound` API
- ensure dynamic builds use the running Python interpreter

## Testing
- `cargo test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_68afa525fe788326927637f2dd8bd72d