### PR TITLE
feat: expose vertices for voronoi infill

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ Implicitus provides a fully implicit pipeline for manufacturing design, enabling
   - `POST /design/submit`: Accepts a finalized spec JSON and maps it to the internal Proto, validating it for downstream processing.
 - **Next steps**: Integrate ongoing conversational edits, branch history, and diff-based review workflows.
 
+### Voronoi infill payload
+
+Responses that include Voronoi edges now also return a matching `vertices` array.
+Each entry in `edges` references two indices into this `vertices` list:
+
+```json
+{
+  "modifiers": {
+    "infill": {
+      "pattern": "voronoi",
+      "seed_points": [[0,0,0], [1,0,0]],
+      "vertices": [[0,0,0], [1,0,0]],
+      "edges": [[0,1]]
+    }
+  }
+}
+```
+
 
 ## Getting Started
 

--- a/design_api/main.py
+++ b/design_api/main.py
@@ -54,6 +54,7 @@ def log_turn(session_id: str, turn_type: str, raw: str, spec: list, summary: Opt
         if mods and isinstance(mods.get("infill"), dict):
             mods["infill"].pop("seed_points", None)
             mods["infill"].pop("cell_vertices", None)
+            mods["infill"].pop("vertices", None)
         scrubbed_spec.append(node_copy)
     entry["spec"] = scrubbed_spec
     if summary is not None:

--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -48,6 +48,7 @@ def generate_voronoi(spec: Dict[str, Any]) -> Dict[str, Any]:
 
     return {
         "seed_points": pts,
+        "vertices": pts,
         "edges": edge_list,
         "cells": spec.get("cells"),
         "bbox_min": spec.get("bbox_min"),

--- a/implicitus-ui/tests/design_api_integration.test.tsx
+++ b/implicitus-ui/tests/design_api_integration.test.tsx
@@ -69,6 +69,7 @@ describe('design_api integration with VoronoiCanvas', () => {
     const body = await resp.json();
     const infill = body.spec[0].modifiers.infill;
     expect(infill.edges.length).toBeGreaterThan(0);
+    expect(infill.vertices.length).toBeGreaterThan(0);
 
     render(
       <VoronoiCanvas


### PR DESCRIPTION
## Summary
- return explicit vertex coordinates with Voronoi edge results
- ensure adapter copies seed points into a `vertices` array when edges are present
- document Voronoi infill payload shape

## Testing
- `pytest`
- `npm test` *(fails: design_api server did not start)*
- `cargo test` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b5146fd5b083268445ffdd6aa41c0c