### PR TITLE
Use Voronoi vertices when rendering struts

### DIFF
--- a/implicitus-ui/src/components/VoronoiStruts.tsx
+++ b/implicitus-ui/src/components/VoronoiStruts.tsx
@@ -3,25 +3,25 @@ import * as THREE from 'three';
 
 
 export interface VoronoiStrutsProps {
-  seedPoints: [number, number, number][];
+  vertices: [number, number, number][];
   edges: [number, number][];      // list of index pairs
   strutRadius: number;
   color?: string | number;
 }
 
 export const VoronoiStruts: React.FC<VoronoiStrutsProps> = ({
-  seedPoints,
+  vertices,
   edges = [],
   strutRadius,
   color = 'white'
 }) => {
-  // Convert index‐pairs to coordinate pairs
+  // Convert index‐pairs to coordinate pairs from Voronoi vertices
   const edgePairs = useMemo(() => {
     return (edges || []).map(([i, j]) => [
-      seedPoints[i] as [number, number, number],
-      seedPoints[j] as [number, number, number]
+      vertices[i] as [number, number, number],
+      vertices[j] as [number, number, number]
     ]);
-  }, [edges, seedPoints]);
+  }, [edges, vertices]);
 
   const meshRef = useRef<THREE.InstancedMesh>(null!);
 


### PR DESCRIPTION
## Summary
- Replace seed point prop with `vertices` in `VoronoiStruts` and build cylinders between Voronoi vertex pairs
- Allow `VoronoiCanvas` to accept Voronoi vertices and filter edges using them before rendering

## Testing
- `pytest`
- `npm test` *(fails: design_api server did not start)*
- `npx vitest run src/components/VoronoiCanvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b517ad2eb4832680fe50e209818d72