### PR TITLE
Expose lattice geometry to UI

### DIFF
--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -146,10 +146,15 @@ def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
     )
 
     if use_voronoi_edges:
+        # ``build_hex_lattice`` returns vertices and edges as tuples. Convert them
+        # into plain lists so the structure can be serialized directly into
+        # JSON without relying on the caller's sanitization step.
+        verts = [list(v) for v in cell_vertices]
+        edges = [list(e) for e in edge_list]
         return {
             "seed_points": seed_pts,
-            "vertices": cell_vertices,
-            "edges": edge_list,
+            "vertices": verts,
+            "edges": edges,
             "cells": cells,
             "bbox_min": bbox_min,
             "bbox_max": bbox_max,

--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -74,9 +74,18 @@ function App() {
   const seedPoints: [number, number, number][] =
     spec[0]?.modifiers?.infill?.seed_points ?? [];
   const edges = meshEdges;
-  // Fetch mesh from core_engine whenever spec seed points change
+  // Use geometry from the spec when available; otherwise, fetch from the
+  // ``core_engine`` service using the seed points.
   useEffect(() => {
-    const seeds = spec[0]?.modifiers?.infill?.seed_points;
+    const infill = spec[0]?.modifiers?.infill;
+    const verts = infill?.vertices;
+    const edgeList = infill?.edges;
+    if (Array.isArray(verts) && verts.length && Array.isArray(edgeList) && edgeList.length) {
+      setMeshVertices(verts);
+      setMeshEdges(edgeList);
+      return; // geometry already provided in spec; skip fetch
+    }
+    const seeds = infill?.seed_points;
     if (seeds && seeds.length > 0) {
       fetch('http://localhost:4000/voronoi', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- ensure `generate_hex_lattice` emits serializable `vertices` and `edges` when Voronoi geometry is requested
- read geometry directly from spec in the React app and fall back to the core-engine fetch only when absent

## Testing
- `pytest`
- `npm test` *(fails: slicer_server integration > returns circular contour and renders without warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a75cf3d88326990c6020701ecb10