### PR TITLE
Handle missing vertices in VoronoiCanvas

### DIFF
--- a/implicitus-ui/src/components/VoronoiCanvas.test.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { generateHexTest3D, computeFilteredEdges } from './VoronoiCanvas';
 import VoronoiCanvas from './VoronoiCanvas';
@@ -41,5 +41,21 @@ describe('VoronoiCanvas warning', () => {
       <VoronoiCanvas seedPoints={[]} edges={[]} bbox={[0, 0, 0, 1, 1, 1]} />
     );
     expect(screen.getByTestId('no-edges-warning')).toBeTruthy();
+  });
+
+  it('logs a warning when vertices are absent', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <VoronoiCanvas
+        seedPoints={[]}
+        vertices={[]}
+        edges={[[0, 1]]}
+        bbox={[0, 0, 0, 1, 1, 1]}
+      />
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no vertices provided')
+    );
+    warn.mockRestore();
   });
 });

--- a/implicitus-ui/src/components/VoronoiCanvas.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.tsx
@@ -241,7 +241,19 @@ const VoronoiCanvas: React.FC<VoronoiCanvasProps> = ({
   DEBUG_CANVAS && console.log('VoronoiCanvas sample validSeedPoints (first 5):', validSeedPoints.slice(0,5));
   // Filter out long edges to avoid hairball: only keep edges shorter than ~1.5× the average edge length
   const filteredEdges = useMemo(() => {
-    DEBUG_CANVAS && console.log('VoronoiCanvas useMemo input:', { validVertices, validEdges, edgeLengthThreshold });
+    if (validVertices.length === 0) {
+      validEdges.length > 0 &&
+        console.warn(
+          'VoronoiCanvas: no vertices provided; skipping edge filtering and strut geometry.'
+        );
+      return [];
+    }
+    DEBUG_CANVAS &&
+      console.log('VoronoiCanvas useMemo input:', {
+        validVertices,
+        validEdges,
+        edgeLengthThreshold,
+      });
     return computeFilteredEdges(validVertices, validEdges, edgeLengthThreshold);
   }, [validEdges, validVertices, edgeLengthThreshold]);
   DEBUG_CANVAS && console.log('VoronoiCanvas filteredEdges count:', filteredEdges.length);


### PR DESCRIPTION
## Summary
- Skip edge filtering when Voronoi vertices are absent and warn developers
- Test warning behavior for missing vertices in VoronoiCanvas

## Testing
- `npx vitest run src/components/VoronoiCanvas.test.tsx` *(fails: Invalid hook call)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac34b0f48326980467481054a6c3