### PR TITLE
chore: add root test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "babel-plugin-glsl": "^1.0.0"
+  },
+  "scripts": {
+    "test": "npm --prefix implicitus-ui test"
   }
 }


### PR DESCRIPTION
## Summary
- add `npm test` script to run the UI test suite via implicitus-ui

## Testing
- `npm test` *(fails: slicer_server integration test, VoronoiCanvas warning test)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2e0f2dc832684785f967e420a62