### PR TITLE
feat(ui): add vitest config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ curl "http://localhost:3000/models/test_sphere/slices?layer=0.0&nx=5&ny=5"
 cd ../
 python3 test_slice.py
 
+## UI Unit Tests
+
+Execute the frontend test suite with [Vitest](https://vitest.dev):
+
+```bash
+cd implicitus-ui
+npm test
+# or
+npx vitest
+```
+
 ## Logging
 
 The Design API configures Python logging before any Voronoi utilities are

--- a/implicitus-ui/README.md
+++ b/implicitus-ui/README.md
@@ -14,6 +14,16 @@ npm run dev
 
 `npm run dev` starts the Vite server. Running `npm install dev` will try to install a package named `dev` which depends on the Linux-only `inotify` module and fails on macOS.
 
+## Running Tests
+
+Use [Vitest](https://vitest.dev) to execute the UI unit tests:
+
+```bash
+npm test
+# or
+npx vitest
+```
+
 ## Current Progress
 
 Our application now includes a full-featured Voronoi lattice generation backend with the following capabilities:

--- a/implicitus-ui/tests/setup.ts
+++ b/implicitus-ui/tests/setup.ts
@@ -1,0 +1,7 @@
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(globalThis as any).ResizeObserver = ResizeObserver

--- a/implicitus-ui/vitest.config.ts
+++ b/implicitus-ui/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
+    globals: true,
+    testTimeout: 30000,
+  },
+})


### PR DESCRIPTION
## Summary
- set up Vitest configuration with jsdom environment for UI
- polyfill ResizeObserver for tests
- document running frontend tests with npm test or npx vitest

## Testing
- `npm test` *(fails: fetch failed on http://127.0.0.1:4000/slice)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b869ae348326a2e6de3b508419d6