### PR TITLE
feat: add z-range diagnostics for Voronoi edges

### DIFF
--- a/docs/mesh_generation.md
+++ b/docs/mesh_generation.md
@@ -16,6 +16,15 @@ both primitive solids and infill structures.
 * Construct Voronoi or lattice cells, yielding explicit vertex coordinates.
 * Produce edge connectivity so downstream tools can build struts or surfaces.
 
+### Edge diagnostics
+
+The front‑end’s `VoronoiCanvas` performs a lightweight sanity check on the
+edges returned from the meshing pipeline. After filtering long edges it warns
+when an edge’s endpoints share nearly the same **z** value—an indication that a
+3D edge may have collapsed into a plane. In development this check can be made
+strict by setting `VORONOI_ASSERT_Z=true`, causing tests to fail fast when such
+degenerate edges appear.
+
 ## Unified Output
 
 The long‑term goal is to have `core_engine` provide a single authoritative


### PR DESCRIPTION
## Summary
- warn when filtered Voronoi edges have near-zero z variation and optionally assert in development
- track z-flat edges in component data attributes
- document the z-range diagnostic for maintainers

## Testing
- `npm test` *(fails: slicer_server integration returns non-ok response)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61b587f20832696c2afeaa743e1c0