### PR TITLE
Handle lattice alias when parsing specs

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -140,6 +140,14 @@ def _build_modifier_dict(raw_spec: dict) -> dict:
     # nested infill
     if isinstance(raw_spec.get('infill'), dict):
         infill_data.update(raw_spec['infill'])
+
+    # Allow 'lattice' as an alias for infill specification
+    if 'lattice' in raw_spec:
+        lattice_val = raw_spec.pop('lattice')
+        if isinstance(lattice_val, str):
+            infill_data['pattern'] = lattice_val
+        elif isinstance(lattice_val, dict):
+            infill_data.update(lattice_val)
     # Normalize bounding box keys to snake_case if they slipped through
     if 'bboxMin' in infill_data:
         infill_data['bbox_min'] = infill_data.pop('bboxMin')

--- a/tests/ai_adapter/test_lattice_alias.py
+++ b/tests/ai_adapter/test_lattice_alias.py
@@ -1,0 +1,12 @@
+from ai_adapter.csg_adapter import parse_raw_spec
+
+
+def test_lattice_alias_parsed_as_infill():
+    spec = {'shape': 'sphere', 'size_mm': 20, 'lattice': 'voronoi'}
+    nodes = parse_raw_spec(spec)
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node['primitive']['sphere']['radius'] == 10.0
+    infill = node.get('modifiers', {}).get('infill', {})
+    assert infill.get('pattern') == 'voronoi'
+


### PR DESCRIPTION
## Summary
- treat `lattice` key as alias for infill pattern in spec parsing
- add regression test for lattice alias handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a76ec4548326a6d1e728f15d69a5