### PR TITLE
Fail tests on Voronoi flat edge warnings

### DIFF
--- a/implicitus-ui/src/components/VoronoiCanvas.test.tsx
+++ b/implicitus-ui/src/components/VoronoiCanvas.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import {
   generateHexTest3D,
@@ -9,6 +9,22 @@ import {
 } from './VoronoiCanvas';
 import VoronoiCanvas from './VoronoiCanvas';
 import { Graph, alg } from 'graphlib';
+
+const originalWarn = console.warn;
+
+beforeEach(() => {
+  console.warn = (...args: any[]) => {
+    const msg = args.join(' ');
+    if (msg.includes('edge z-range below tolerance')) {
+      throw new Error(msg);
+    }
+    return originalWarn(...args);
+  };
+});
+
+afterEach(() => {
+  console.warn = originalWarn;
+});
 
 describe('VoronoiCanvas filteredEdges', () => {
   it('produces uniform edge lengths and a single connected component', () => {

--- a/implicitus-ui/tests/voronoi_canvas.visual.spec.ts
+++ b/implicitus-ui/tests/voronoi_canvas.visual.spec.ts
@@ -24,10 +24,19 @@ test.afterAll(async () => {
 });
 
 test('VoronoiCanvas visual regression', async ({ page }) => {
-  page.on('pageerror', err => console.error('pageerror:', err));
-  page.on('console', msg => console.log('console:', msg.text()));
+  page.on('pageerror', err => { throw err; });
+  page.on('console', msg => {
+    if (
+      msg.type() === 'warning' &&
+      msg.text().includes('edge z-range below tolerance')
+    ) {
+      throw new Error(msg.text());
+    }
+  });
   await page.addInitScript(() => {
-    (window as any).process = { env: { NODE_ENV: 'test' } };
+    (window as any).process = {
+      env: { NODE_ENV: 'test', VORONOI_ASSERT_Z: 'true' }
+    };
   });
   await page.goto('http://localhost:3000/tests/visual/voronoi_canvas_page.html');
   const root = page.locator('[data-testid="voronoi-canvas-root"]');


### PR DESCRIPTION
## Summary
- throw on flat-edge warnings in VoronoiCanvas tests to surface unexpected geometry issues
- Playwright visual test aborts on flat-edge warnings and asserts non-flat data

## Testing
- `npm --prefix implicitus-ui test`
- `npm --prefix implicitus-ui run test:playwright` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm --prefix implicitus-ui run lint` *(fails: ✖ 27 problems (13 errors, 14 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b7aaf8083c8326819169afb4375d67