### PR TITLE
Add Voronoi handoff debug logging

### DIFF
--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -87,7 +87,16 @@ pub async fn handle_slice(req: SliceRequest) -> Result<impl warp::Reply, warp::R
 }
 
 async fn handle_voronoi(req: VoronoiRequest) -> Result<impl warp::Reply, warp::Rejection> {
+    println!(
+        "[slicer_server] /voronoi request: {} seeds", 
+        req.seeds.len()
+    );
     let mesh = voronoi_mesh(&req.seeds);
+    println!(
+        "[slicer_server] /voronoi response: {} vertices, {} edges",
+        mesh.vertices.len(),
+        mesh.edges.len()
+    );
     let resp = VoronoiResponse {
         vertices: mesh.vertices,
         edges: mesh.edges,

--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -87,17 +87,25 @@ function App() {
     }
     const seeds = infill?.seed_points;
     if (seeds && seeds.length > 0) {
+      console.debug('[UI] Fetching Voronoi mesh from slicer server', { count: seeds.length });
       fetch('http://localhost:4000/voronoi', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ seeds }),
       })
-        .then(res => res.json())
+        .then(res => {
+          console.debug('[UI] Voronoi response status', res.status);
+          return res.json();
+        })
         .then(data => {
+          console.debug('[UI] Voronoi mesh received', {
+            vertices: data.vertices?.length,
+            edges: data.edges?.length,
+          });
           setMeshVertices(data.vertices || []);
           setMeshEdges(data.edges || []);
         })
-        .catch(err => console.error('Mesh fetch failed', err));
+        .catch(err => console.error('[UI] Mesh fetch failed', err));
     }
   }, [spec]);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- log outgoing Voronoi mesh requests and response sizes in the UI
- print seed counts and mesh dimensions for `/voronoi` requests in slicer server

## Testing
- `npm --prefix implicitus-ui test`
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7ad4912288326b0d2a4e7af751fc3