### PR TITLE
Clamp default voronoi seed generation to 1000 points

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -9,9 +9,12 @@ from ai_adapter import rust_primitives
 
 # Maximum number of voronoi seed points to avoid huge arrays
 MAX_SEED_POINTS = 7500
+# Default number of voronoi seed points when unspecified
+DEFAULT_SEED_POINTS = 1000
 
 # --- Helper functions for voronoi seed generation ---
 import random
+
 
 def _parse_bool(value):
     """Robustly interpret a JSON boolean that may arrive as a string."""
@@ -21,31 +24,35 @@ def _parse_bool(value):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
 
+
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
+
 
 # Helper for bounding box calculation for primitives
 def _compute_bbox_from_primitive(prim: dict):
     """
     Given a primitive dict, return (bbox_min, bbox_max) in object space.
     """
-    if 'box' in prim:
-        sz = prim['box']['size']
-        half_x, half_y, half_z = sz['x'] / 2.0, sz['y'] / 2.0, sz['z'] / 2.0
+    if "box" in prim:
+        sz = prim["box"]["size"]
+        half_x, half_y, half_z = sz["x"] / 2.0, sz["y"] / 2.0, sz["z"] / 2.0
         return (-half_x, -half_y, -half_z), (half_x, half_y, half_z)
-    if 'cube' in prim:
-        s = prim['cube']['size']
+    if "cube" in prim:
+        s = prim["cube"]["size"]
         half = s / 2.0
         return (-half, -half, -half), (half, half, half)
-    if 'sphere' in prim:
-        r = prim['sphere']['radius']
+    if "sphere" in prim:
+        r = prim["sphere"]["radius"]
         return (-r, -r, -r), (r, r, r)
-    if 'cylinder' in prim:
-        h = prim['cylinder']['height']
-        r = prim['cylinder']['radius']
+    if "cylinder" in prim:
+        h = prim["cylinder"]["height"]
+        r = prim["cylinder"]["radius"]
         return (-r, -r, 0.0), (r, r, h)
     # default fallback
     return (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)
+
 
 # Lazily import the LLM pipeline so that tests can run without the heavy
 # `transformers` dependency.  Functions that rely on the pipeline will raise a
@@ -53,41 +60,43 @@ def _compute_bbox_from_primitive(prim: dict):
 try:  # pragma: no cover - exercised in integration environments
     from ai_adapter.inference_pipeline import generate as llm_generate
 except Exception:  # pragma: no cover - fall back to a stub
+
     def llm_generate(*_args, **_kwargs):
         raise RuntimeError("LLM inference pipeline is not available")
 
+
 import re
+
 
 # Ensure any infill that includes edges also exposes a matching vertex list.
 def _ensure_vertices_for_edges(nodes):
     for node in nodes:
-        infill = node.get('modifiers', {}).get('infill')
-        if isinstance(infill, dict) and 'edges' in infill and 'vertices' not in infill:
-            verts = infill.get('seed_points')
+        infill = node.get("modifiers", {}).get("infill")
+        if isinstance(infill, dict) and "edges" in infill and "vertices" not in infill:
+            verts = infill.get("seed_points")
             if verts is not None:
-                infill['vertices'] = verts
+                infill["vertices"] = verts
+
 
 # declarative requirements for primitives and modifiers
 PRIMITIVE_REQUIREMENTS = {
     "sphere": {"oneOf": [["size_mm", "radius_mm"]]},
-    "cube":   {"required": ["size_mm"]},
-    "box":    {"required": ["size_mm"]},
+    "cube": {"required": ["size_mm"]},
+    "box": {"required": ["size_mm"]},
     "cylinder": {"oneOf": [["size_mm"], ["radius_mm", "height_mm"]]},
     # extend with more primitives as needed...
     "voronoi": {
         "required": ["seed_points", "bbox_min", "bbox_max"],
-        "oneOf": [["min_dist"], ["density_field"], ["scale_field"]]
+        "oneOf": [["min_dist"], ["density_field"], ["scale_field"]],
     },
 }
 
 MODIFIER_REQUIREMENTS = {
     # Infill must include a pattern; density is optional for voronoi
-    "infill": {
-        "required": ["pattern"],
-        "oneOf": [["density"], []]
-    },
+    "infill": {"required": ["pattern"], "oneOf": [["density"], []]},
     # extend with more modifiers (shell, boolean, etc.) as needed...
 }
+
 
 def _check_requirements(raw_spec: dict, shape: str) -> list[str]:
     """
@@ -104,6 +113,7 @@ def _check_requirements(raw_spec: dict, shape: str) -> list[str]:
         if not any(k in raw_spec and raw_spec.get(k) is not None for k in group):
             missing.append(f"one of {group}")
     return missing
+
 
 def _find_missing_fields(raw_spec):
     """
@@ -126,6 +136,7 @@ def _find_missing_fields(raw_spec):
                         missing.append(f"{shape} {mod}: missing {key}")
     return missing
 
+
 def _build_modifier_dict(raw_spec: dict) -> dict:
     """
     Normalize any infill specification, whether it comes as a nested dict
@@ -134,122 +145,151 @@ def _build_modifier_dict(raw_spec: dict) -> dict:
     """
     # Support top-level string infill flag (e.g., "infill": "voronoi")
     infill_data = {}
-    if 'infill' in raw_spec and isinstance(raw_spec['infill'], str):
-        infill_data['pattern'] = raw_spec.pop('infill')
+    if "infill" in raw_spec and isinstance(raw_spec["infill"], str):
+        infill_data["pattern"] = raw_spec.pop("infill")
 
     # nested infill
-    if isinstance(raw_spec.get('infill'), dict):
-        infill_data.update(raw_spec['infill'])
+    if isinstance(raw_spec.get("infill"), dict):
+        infill_data.update(raw_spec["infill"])
 
     # Allow 'lattice' as an alias for infill specification
-    if 'lattice' in raw_spec:
-        lattice_val = raw_spec.pop('lattice')
+    if "lattice" in raw_spec:
+        lattice_val = raw_spec.pop("lattice")
         if isinstance(lattice_val, str):
-            infill_data['pattern'] = lattice_val
+            infill_data["pattern"] = lattice_val
         elif isinstance(lattice_val, dict):
             infill_data.update(lattice_val)
     # Normalize bounding box keys to snake_case if they slipped through
-    if 'bboxMin' in infill_data:
-        infill_data['bbox_min'] = infill_data.pop('bboxMin')
-    if 'bboxMax' in infill_data:
-        infill_data['bbox_max'] = infill_data.pop('bboxMax')
+    if "bboxMin" in infill_data:
+        infill_data["bbox_min"] = infill_data.pop("bboxMin")
+    if "bboxMax" in infill_data:
+        infill_data["bbox_max"] = infill_data.pop("bboxMax")
     # flattened fields
-    if 'infill_pattern' in raw_spec:
-        infill_data['pattern'] = raw_spec.pop('infill_pattern')
-    if 'infill_shape' in raw_spec:
-        infill_data['pattern'] = raw_spec.pop('infill_shape')
-    if 'infill_density' in raw_spec:
-        infill_data['density'] = raw_spec.pop('infill_density')
-    if 'infill_thickness_mm' in raw_spec:
-        infill_data['density'] = raw_spec.pop('infill_thickness_mm')
-    if 'infill_mm' in raw_spec:
-        infill_data['density'] = raw_spec.pop('infill_mm')
+    if "infill_pattern" in raw_spec:
+        infill_data["pattern"] = raw_spec.pop("infill_pattern")
+    if "infill_shape" in raw_spec:
+        infill_data["pattern"] = raw_spec.pop("infill_shape")
+    if "infill_density" in raw_spec:
+        infill_data["density"] = raw_spec.pop("infill_density")
+    if "infill_thickness_mm" in raw_spec:
+        infill_data["density"] = raw_spec.pop("infill_thickness_mm")
+    if "infill_mm" in raw_spec:
+        infill_data["density"] = raw_spec.pop("infill_mm")
 
     # Support flattened infill_type field (alias for pattern)
-    if 'infill_type' in raw_spec:
-        infill_data['pattern'] = raw_spec.pop('infill_type')
+    if "infill_type" in raw_spec:
+        infill_data["pattern"] = raw_spec.pop("infill_type")
 
     # Support flattened infill_voronoi boolean flag
     # (remove or adjust if redundant with the top-level string handling)
-    if 'infill_voronoi' in raw_spec:
-        if raw_spec.pop('infill_voronoi'):
-            infill_data['pattern'] = 'voronoi'
+    if "infill_voronoi" in raw_spec:
+        if raw_spec.pop("infill_voronoi"):
+            infill_data["pattern"] = "voronoi"
         # leave density to downstream defaults if missing
 
     # Normalize 'type' to 'pattern' and 'thickness_mm' to 'density'
-    if 'type' in infill_data:
-        infill_data['pattern'] = infill_data.pop('type')
-    if 'thickness_mm' in infill_data:
-        infill_data['density'] = infill_data.pop('thickness_mm')
+    if "type" in infill_data:
+        infill_data["pattern"] = infill_data.pop("type")
+    if "thickness_mm" in infill_data:
+        infill_data["density"] = infill_data.pop("thickness_mm")
 
-    pattern = infill_data.get('pattern')
+    pattern = infill_data.get("pattern")
     # Mark Voronoi infill specially
-    if pattern == 'voronoi':
-        infill_data['_is_voronoi'] = True
-        infill_data.setdefault('uniform', True)
-    if pattern == 'honeycomb':
+    if pattern == "voronoi":
+        infill_data["_is_voronoi"] = True
+        infill_data.setdefault("uniform", True)
+    if pattern == "honeycomb":
         # Treat honeycomb as a voronoi lattice with uniform sampling
-        infill_data['_is_voronoi'] = True
-        infill_data['pattern'] = 'voronoi'
-        infill_data.setdefault('uniform', True)
-    density = infill_data.get('density')
+        infill_data["_is_voronoi"] = True
+        infill_data["pattern"] = "voronoi"
+        infill_data.setdefault("uniform", True)
+    density = infill_data.get("density")
     if pattern is not None and density is not None:
-        return {'pattern': pattern, 'density': density, **({k: v for k, v in infill_data.items() if k not in ('pattern', 'density')})}
+        return {
+            "pattern": pattern,
+            "density": density,
+            **(
+                {
+                    k: v
+                    for k, v in infill_data.items()
+                    if k not in ("pattern", "density")
+                }
+            ),
+        }
     # Allow just pattern (for voronoi, density may be omitted)
     if pattern is not None:
-        return {'pattern': pattern, **({k: v for k, v in infill_data.items() if k != 'pattern'})}
+        return {
+            "pattern": pattern,
+            **({k: v for k, v in infill_data.items() if k != "pattern"}),
+        }
     return {}
+
 
 # mapping from LLM 'shape' string to (proto field name, field-builder function)
 _SHAPE_FIELD_MAP = {
-    'sphere': ('sphere', lambda size: {'radius': size / 2}),
-    'cube':   ('cube',   lambda size: {'size': size}),
-    'box':    ('box',    lambda size: {'size': {'x': size, 'y': size, 'z': size}}),
-    'cylinder': ('cylinder', lambda size: {'height': size, 'radius': size / 2}),
+    "sphere": ("sphere", lambda size: {"radius": size / 2}),
+    "cube": ("cube", lambda size: {"size": size}),
+    "box": ("box", lambda size: {"size": {"x": size, "y": size, "z": size}}),
+    "cylinder": ("cylinder", lambda size: {"height": size, "radius": size / 2}),
     # extend as more primitives are supported...
 }
 
+
 def _build_primitive_dict(spec):
-    raw_shape = spec.get('shape', '').strip().lower()
-    if raw_shape == 'voronoi':
+    raw_shape = spec.get("shape", "").strip().lower()
+    if raw_shape == "voronoi":
         allowed = {
-            'seed_points', 'bbox_min', 'bbox_max',
-            'min_dist', 'density_field', 'scale_field',
-            'adaptive', 'max_depth', 'threshold', 'error_metric',
-            'resolution', 'wall_thickness', 'shell_offset',
-            'blend_curve', 'csg_ops', 'auto_cap', 'cap_blend'
+            "seed_points",
+            "bbox_min",
+            "bbox_max",
+            "min_dist",
+            "density_field",
+            "scale_field",
+            "adaptive",
+            "max_depth",
+            "threshold",
+            "error_metric",
+            "resolution",
+            "wall_thickness",
+            "shell_offset",
+            "blend_curve",
+            "csg_ops",
+            "auto_cap",
+            "cap_blend",
         }
         params = {k: spec[k] for k in allowed if k in spec}
-        return {'voronoi': params}
+        return {"voronoi": params}
     # Special handling for cylinder when size_mm is a dict with radius and height
-    if raw_shape == 'cylinder' and isinstance(spec.get('size_mm'), dict):
-        size_info = spec['size_mm']
-        radius = float(size_info.get('radius', size_info.get('radius_mm', 0)))
-        height = float(size_info.get('height', size_info.get('height_mm', 0)))
-        return {'cylinder': {'radius': radius, 'height': height}}
+    if raw_shape == "cylinder" and isinstance(spec.get("size_mm"), dict):
+        size_info = spec["size_mm"]
+        radius = float(size_info.get("radius", size_info.get("radius_mm", 0)))
+        height = float(size_info.get("height", size_info.get("height_mm", 0)))
+        return {"cylinder": {"radius": radius, "height": height}}
     # Special handling for cylinder with explicit radius_mm and/or height_mm
-    if raw_shape == 'cylinder' and ('radius_mm' in spec or 'height_mm' in spec):
-        radius = float(spec.get('radius_mm', spec.get('radiusMm', 0)))
-        height = float(spec.get('height_mm', spec.get('heightMm', 0)))
-        return {'cylinder': {'radius': radius, 'height': height}}
+    if raw_shape == "cylinder" and ("radius_mm" in spec or "height_mm" in spec):
+        radius = float(spec.get("radius_mm", spec.get("radiusMm", 0)))
+        height = float(spec.get("height_mm", spec.get("heightMm", 0)))
+        return {"cylinder": {"radius": radius, "height": height}}
     # Special handling for sphere: use radius_mm directly if given, otherwise treat size_mm as diameter
-    if raw_shape == 'sphere':
+    if raw_shape == "sphere":
         # prefer explicit radius
-        if 'radius_mm' in spec or 'radiusMm' in spec:
-            radius = float(spec.get('radius_mm') or spec.get('radiusMm'))
+        if "radius_mm" in spec or "radiusMm" in spec:
+            radius = float(spec.get("radius_mm") or spec.get("radiusMm"))
         else:
-            diameter = float(spec.get('size_mm') or spec.get('sizeMm'))
+            diameter = float(spec.get("size_mm") or spec.get("sizeMm"))
             radius = diameter / 2.0
-        return {'sphere': {'radius': radius}}
+        return {"sphere": {"radius": radius}}
     if raw_shape not in _SHAPE_FIELD_MAP:
         raise ValueError(f"Unknown shape '{raw_shape}' in spec")
     field_name, build_fields = _SHAPE_FIELD_MAP[raw_shape]
-    params = build_fields(float(spec.get('size_mm') or spec.get('sizeMm')))
+    params = build_fields(float(spec.get("size_mm") or spec.get("sizeMm")))
     primitive = {field_name: params}
     return primitive
 
+
 def parse_raw_spec(llm_output):
     logging.debug(f"parse_raw_spec received input: {repr(llm_output)}")
+
     # If the input is already a list of nodes in our internal format, return as is.
     def _is_internal_node_dict(d):
         # Only a dict with exactly key "primitive", or with exactly keys "infill" and "children"
@@ -262,7 +302,9 @@ def parse_raw_spec(llm_output):
             return True
         return False
 
-    if isinstance(llm_output, list) and all(_is_internal_node_dict(item) for item in llm_output):
+    if isinstance(llm_output, list) and all(
+        _is_internal_node_dict(item) for item in llm_output
+    ):
         return llm_output
 
     # If the input is already a single node dict in internal format, wrap it in a list.
@@ -277,10 +319,10 @@ def parse_raw_spec(llm_output):
             raise TypeError(f"Failed to parse JSON from string input: {e}")
 
     # Expect a dict with optional 'primitives' list, or a list of spec-dicts
-    if isinstance(llm_output, dict) and 'primitives' in llm_output:
-        specs = llm_output['primitives']
-    elif isinstance(llm_output, dict) and 'shapes' in llm_output:
-        specs = llm_output['shapes']
+    if isinstance(llm_output, dict) and "primitives" in llm_output:
+        specs = llm_output["primitives"]
+    elif isinstance(llm_output, dict) and "shapes" in llm_output:
+        specs = llm_output["shapes"]
     elif isinstance(llm_output, dict):
         specs = [llm_output]
     elif isinstance(llm_output, list):
@@ -291,12 +333,13 @@ def parse_raw_spec(llm_output):
     for spec in specs:
         modifier = _build_modifier_dict(spec)
         primitive_params = _build_primitive_dict(spec)
-        node = {'primitive': primitive_params}
+        node = {"primitive": primitive_params}
         if modifier:
             # Attach infill (or other) modifier under 'modifiers'
-            node.setdefault('modifiers', {})['infill'] = modifier
+            node.setdefault("modifiers", {})["infill"] = modifier
         nodes.append(node)
     return nodes
+
 
 def interpret_llm_request(llm_output):
     logging.debug(f"interpret_llm_request received input: {repr(llm_output)}")
@@ -313,10 +356,12 @@ def interpret_llm_request(llm_output):
             "Return only the updated list of primitive spec dicts as JSON."
         )
         generated = llm_generate(prompt)
-        logging.debug("interpret_llm_request received update-generated JSON: %r", generated)
+        logging.debug(
+            "interpret_llm_request received update-generated JSON: %r", generated
+        )
         # Attempt to parse the last JSON block in case LLM returned multiple arrays
         text = generated.strip()
-        parts = re.split(r'\n\s*\n', text)
+        parts = re.split(r"\n\s*\n", text)
         last_block = parts[-1]
         try:
             update_list = json.loads(last_block)
@@ -325,41 +370,44 @@ def interpret_llm_request(llm_output):
                 update_list = json.loads(parts[0])
             except json.JSONDecodeError:
                 raise RuntimeError(f"Failed to parse LLM update JSON: {generated}")
-        logging.debug("interpret_llm_request parsed update-generated JSON into dict: %r", update_list)
+        logging.debug(
+            "interpret_llm_request parsed update-generated JSON into dict: %r",
+            update_list,
+        )
         # Convert any internal-node dicts (with 'primitive') back into raw spec dicts, mapping fields by shape
         raw_specs = []
         for node in update_list:
-            if isinstance(node, dict) and 'primitive' in node:
-                prim = node['primitive']
+            if isinstance(node, dict) and "primitive" in node:
+                prim = node["primitive"]
                 shape, params = next(iter(prim.items()))
-                raw = {'shape': shape}
+                raw = {"shape": shape}
                 # Map back to raw spec fields by shape
-                if shape == 'sphere':
+                if shape == "sphere":
                     # radius -> radius_mm
-                    raw['radius_mm'] = params.get('radius')
-                elif shape in ('cube', 'box'):
-                    size = params.get('size')
+                    raw["radius_mm"] = params.get("radius")
+                elif shape in ("cube", "box"):
+                    size = params.get("size")
                     # If size is dict, check for uniform dimensions
                     if isinstance(size, dict):
-                        x, y, z = size.get('x'), size.get('y'), size.get('z')
+                        x, y, z = size.get("x"), size.get("y"), size.get("z")
                         if x == y == z:
-                            raw['size_mm'] = x
+                            raw["size_mm"] = x
                         else:
-                            raw['size_mm'] = [x, y, z]
+                            raw["size_mm"] = [x, y, z]
                     else:
-                        raw['size_mm'] = size
-                elif shape == 'cylinder':
-                    raw['radius_mm'] = params.get('radius')
-                    raw['height_mm'] = params.get('height')
+                        raw["size_mm"] = size
+                elif shape == "cylinder":
+                    raw["radius_mm"] = params.get("radius")
+                    raw["height_mm"] = params.get("height")
                 else:
                     # Fallback: merge all params directly
                     raw.update(params)
                 # preserve infill flag if present
-                if 'infill' in params:
-                    raw['infill'] = params.get('infill')
+                if "infill" in params:
+                    raw["infill"] = params.get("infill")
                 # also support the infill_type alias
-                if 'infill_type' in params:
-                    raw['infill'] = params.get('infill_type')
+                if "infill_type" in params:
+                    raw["infill"] = params.get("infill_type")
                 raw_specs.append(raw)
             else:
                 raw_specs.append(node)
@@ -367,34 +415,39 @@ def interpret_llm_request(llm_output):
         nodes = parse_raw_spec(raw_specs)
         # Enrich any voronoi modifiers with defaults
         for node in nodes:
-            infill = node.get('modifiers', {}).get('infill')
-            if isinstance(infill, dict) and infill.get('_is_voronoi'):
-                prim = node['primitive']
+            infill = node.get("modifiers", {}).get("infill")
+            if isinstance(infill, dict) and infill.get("_is_voronoi"):
+                prim = node["primitive"]
                 bbox_min, bbox_max = _compute_bbox_from_primitive(prim)
                 size = [bbox_max[i] - bbox_min[i] for i in range(3)]
-                infill.setdefault('min_dist', max(size) / 20.0)
-                infill.setdefault('wall_thickness', size[2] / 50.0)
-                infill.setdefault('bbox_min', list(bbox_min))
-                infill.setdefault('bbox_max', list(bbox_max))
+                infill.setdefault("min_dist", max(size) / 20.0)
+                infill.setdefault("wall_thickness", size[2] / 50.0)
+                infill.setdefault("bbox_min", list(bbox_min))
+                infill.setdefault("bbox_max", list(bbox_max))
                 # surface uniform‐sampling toggle in spec
-                infill.setdefault('uniform', True)
+                infill.setdefault("uniform", True)
                 # Auto-generate seed points inside the primitive if missing
-                shape, _params = next(iter(node['primitive'].items()))
-                if 'seed_points' not in infill:
-                    uniform = _parse_bool(infill.get('uniform', True))
-                    infill['uniform'] = uniform
+                shape, _params = next(iter(node["primitive"].items()))
+                if "seed_points" not in infill:
+                    uniform = _parse_bool(infill.get("uniform", True))
+                    infill["uniform"] = uniform
                     logging.debug(
                         f"interpret_llm_request update-branch: uniform sampling={uniform}"
                     )
-                    seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+                    seeds = rust_primitives.sample_inside(
+                        node["primitive"], infill["min_dist"]
+                    )
                     if len(seeds) > MAX_SEED_POINTS:
                         seeds = seeds[:MAX_SEED_POINTS]
-                    infill.setdefault('num_points', len(seeds))
-                    if 'num_points' in infill:
+                    infill.setdefault(
+                        "num_points", min(len(seeds), DEFAULT_SEED_POINTS)
+                    )
+                    if "num_points" in infill:
                         import random
+
                         random.shuffle(seeds)
-                        seeds = seeds[: int(infill['num_points'])]
-                    infill['seed_points'] = seeds
+                        seeds = seeds[: int(infill["num_points"])]
+                    infill["seed_points"] = seeds
                     logging.debug(
                         f"interpret_llm_request: generated {len(seeds)} seed points for {shape}"
                     )
@@ -410,11 +463,17 @@ def interpret_llm_request(llm_output):
             logging.debug("interpret_llm_request parsed input as JSON: %r", raw)
         except json.JSONDecodeError:
             # not JSON, call the LLM to turn natural language into JSON
-            logging.debug("interpret_llm_request calling LLM for JSON generation on: %r", raw)
+            logging.debug(
+                "interpret_llm_request calling LLM for JSON generation on: %r", raw
+            )
             generated = llm_generate(raw)
-            logging.debug("interpret_llm_request received generated JSON: %r", generated)
+            logging.debug(
+                "interpret_llm_request received generated JSON: %r", generated
+            )
             raw = json.loads(generated)
-            logging.debug("interpret_llm_request parsed generated JSON into dict: %r", raw)
+            logging.debug(
+                "interpret_llm_request parsed generated JSON into dict: %r", raw
+            )
 
     # Check for any required fields that are still missing
     missing = _find_missing_fields(raw)
@@ -438,64 +497,65 @@ def interpret_llm_request(llm_output):
     if isinstance(raw, dict):
         modifier = _build_modifier_dict(raw)
         if modifier:
-            raw['infill'] = modifier
-            logging.debug("interpret_llm_request applied _build_modifier_dict: %r", modifier)
+            raw["infill"] = modifier
+            logging.debug(
+                "interpret_llm_request applied _build_modifier_dict: %r", modifier
+            )
 
     nodes = parse_raw_spec(raw)
     # Enrich any voronoi modifiers with defaults
     for node in nodes:
-        infill = node.get('modifiers', {}).get('infill')
-        if isinstance(infill, dict) and infill.get('_is_voronoi'):
-            prim = node['primitive']
+        infill = node.get("modifiers", {}).get("infill")
+        if isinstance(infill, dict) and infill.get("_is_voronoi"):
+            prim = node["primitive"]
             bbox_min, bbox_max = _compute_bbox_from_primitive(prim)
             size = [bbox_max[i] - bbox_min[i] for i in range(3)]
-            infill.setdefault('min_dist', max(size) / 20.0)
-            infill.setdefault('wall_thickness', size[2] / 50.0)
-            infill.setdefault('bbox_min', list(bbox_min))
-            infill.setdefault('bbox_max', list(bbox_max))
+            infill.setdefault("min_dist", max(size) / 20.0)
+            infill.setdefault("wall_thickness", size[2] / 50.0)
+            infill.setdefault("bbox_min", list(bbox_min))
+            infill.setdefault("bbox_max", list(bbox_max))
             # surface uniform‐sampling toggle in spec
-            infill.setdefault('uniform', True)
+            infill.setdefault("uniform", True)
             # Also support uniform/resolution for auto seed generation if seed_points missing
-            if 'seed_points' not in infill:
-                shape, _params = next(iter(node['primitive'].items()))
-                uniform = _parse_bool(infill.get('uniform', True))
-                infill['uniform'] = uniform
+            if "seed_points" not in infill:
+                shape, _params = next(iter(node["primitive"].items()))
+                uniform = _parse_bool(infill.get("uniform", True))
+                infill["uniform"] = uniform
                 logging.debug(
                     f"interpret_llm_request update-branch: uniform sampling={uniform}"
                 )
-                seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+                seeds = rust_primitives.sample_inside(
+                    node["primitive"], infill["min_dist"]
+                )
                 if len(seeds) > MAX_SEED_POINTS:
                     seeds = seeds[:MAX_SEED_POINTS]
-                infill.setdefault('num_points', len(seeds))
-                if 'num_points' in infill:
+                infill.setdefault("num_points", min(len(seeds), DEFAULT_SEED_POINTS))
+                if "num_points" in infill:
                     import random
+
                     random.shuffle(seeds)
-                    seeds = seeds[: int(infill['num_points'])]
-                infill['seed_points'] = seeds
+                    seeds = seeds[: int(infill["num_points"])]
+                infill["seed_points"] = seeds
                 logging.debug(
                     f"interpret_llm_request: generated {len(seeds)} seed points for {shape}"
                 )
     return {"primitives": nodes}
 
+
 def build_model_from_spec(nodes, boolean_op=None):
     # Wrap nodes into root based on boolean_op or count
     if boolean_op:
-        root = {
-            'booleanOp': {boolean_op: {}},
-            'children': nodes
-        }
+        root = {"booleanOp": {boolean_op: {}}, "children": nodes}
     elif len(nodes) > 1:
-        root = {'children': nodes}
+        root = {"children": nodes}
     else:
         root = nodes[0]
 
-    model_dict = {
-        'id': str(uuid.uuid4()),
-        'root': root
-    }
+    model_dict = {"id": str(uuid.uuid4()), "root": root}
     proto = Model()
     json_format.ParseDict(model_dict, proto)
     return proto
+
 
 def parse_and_build_model(llm_output):
     """
@@ -504,46 +564,53 @@ def parse_and_build_model(llm_output):
     """
     return interpret_llm_request(llm_output)
 
+
 def generate_summary(spec):
     segments = []
     for action in spec:
         # handle direct primitives
-        if 'primitive' in action:
-            prim = action['primitive']
+        if "primitive" in action:
+            prim = action["primitive"]
             for shape, details in prim.items():
-                if shape == 'sphere':
+                if shape == "sphere":
                     segments.append(f"sphere radius {details['radius']}")
-                elif shape == 'box':
-                    size = details['size']
+                elif shape == "box":
+                    size = details["size"]
                     segments.append(f"box size {size['x']}x{size['y']}x{size['z']}")
-                elif shape == 'cylinder':
-                    segments.append(f"cylinder radius {details['radius']} height {details['height']}")
+                elif shape == "cylinder":
+                    segments.append(
+                        f"cylinder radius {details['radius']} height {details['height']}"
+                    )
                 else:
                     segments.append(shape)
         # handle compound actions with children
-        if 'children' in action:
-            for child in action['children']:
-                if 'primitive' in child:
-                    prim = child['primitive']
+        if "children" in action:
+            for child in action["children"]:
+                if "primitive" in child:
+                    prim = child["primitive"]
                     for shape, details in prim.items():
-                        if shape == 'sphere':
+                        if shape == "sphere":
                             segments.append(f"sphere radius {details['radius']}")
-                        elif shape == 'box':
-                            size = details['size']
-                            segments.append(f"box size {size['x']}x{size['y']}x{size['z']}")
-                        elif shape == 'cylinder':
-                            segments.append(f"cylinder radius {details['radius']} height {details['height']}")
+                        elif shape == "box":
+                            size = details["size"]
+                            segments.append(
+                                f"box size {size['x']}x{size['y']}x{size['z']}"
+                            )
+                        elif shape == "cylinder":
+                            segments.append(
+                                f"cylinder radius {details['radius']} height {details['height']}"
+                            )
                         else:
                             segments.append(shape)
         # handle modifiers like infill (nested under 'modifiers')
-        infill = action.get('modifiers', {}).get('infill')
+        infill = action.get("modifiers", {}).get("infill")
         if isinstance(infill, dict):
-            pattern = infill.get('pattern')
-            density = infill.get('density')
+            pattern = infill.get("pattern")
+            density = infill.get("density")
             # determine primary shape name
-            shape = ''
-            if 'primitive' in action:
-                shape = next(iter(action['primitive'].keys()), '')
+            shape = ""
+            if "primitive" in action:
+                shape = next(iter(action["primitive"].keys()), "")
             segments.append(f"{shape} infill pattern {pattern} density {density}")
     return "; ".join(segments)
 
@@ -562,6 +629,7 @@ def confirm_change(old_nodes, new_nodes, instruction):
     )
     confirmation = llm_generate(prompt)
     return confirmation.strip()
+
 
 def review_request(request_data):
     """
@@ -593,21 +661,23 @@ def review_request(request_data):
         return spec, summary
 
     # Manual JSON-only spec from UI: parse and summarize directly
-    if isinstance(request_data, dict) and ("shape" in request_data or "primitives" in request_data):
+    if isinstance(request_data, dict) and (
+        "shape" in request_data or "primitives" in request_data
+    ):
         # parse the raw spec without calling the LLM
         nodes = parse_raw_spec(request_data)
         # Enrich any voronoi modifiers with default parameters on review
         for node in nodes:
-            infill = node.get('modifiers', {}).get('infill')
-            if isinstance(infill, dict) and infill.get('_is_voronoi'):
-                prim = node['primitive']
+            infill = node.get("modifiers", {}).get("infill")
+            if isinstance(infill, dict) and infill.get("_is_voronoi"):
+                prim = node["primitive"]
                 bbox_min, bbox_max = _compute_bbox_from_primitive(prim)
                 size = [bbox_max[i] - bbox_min[i] for i in range(3)]
-                infill.setdefault('min_dist', max(size) / 20.0)
-                infill.setdefault('wall_thickness', size[2] / 50.0)
-                infill.setdefault('bbox_min', list(bbox_min))
-                infill.setdefault('bbox_max', list(bbox_max))
-                infill.setdefault('uniform', True)
+                infill.setdefault("min_dist", max(size) / 20.0)
+                infill.setdefault("wall_thickness", size[2] / 50.0)
+                infill.setdefault("bbox_min", list(bbox_min))
+                infill.setdefault("bbox_max", list(bbox_max))
+                infill.setdefault("uniform", True)
         _ensure_vertices_for_edges(nodes)
         summary = generate_summary(nodes)
         return nodes, summary
@@ -627,10 +697,7 @@ def review_request(request_data):
     # Interpret through our standard pipeline
     interpreted = interpret_llm_request(raw)
     if isinstance(interpreted, dict) and interpreted.get("needsClarification"):
-        response = {
-            "needsClarification": True,
-            "question": interpreted["question"]
-        }
+        response = {"needsClarification": True, "question": interpreted["question"]}
         # Include sid if present in the original request
         sid = request_data.get("sid") if isinstance(request_data, dict) else None
         if sid:
@@ -649,27 +716,30 @@ def update_request(sid: str, spec: list, raw: str):
     Returns a tuple: (new_spec, new_summary)
     """
     # Quick parse for simple infill commands like "add a 2mm gyroid infill"
-    m = re.search(r'(\d+(?:\.\d+)?)\s*mm\s+(\w+)\s+infill', raw.lower())
+    m = re.search(r"(\d+(?:\.\d+)?)\s*mm\s+(\w+)\s+infill", raw.lower())
     if m:
         thickness = float(m.group(1))
         pattern = m.group(2)
         # apply infill to all primitives, nesting under modifiers
         for action in spec:
-            action.setdefault('modifiers', {})['infill'] = {'pattern': pattern, 'density': thickness}
+            action.setdefault("modifiers", {})["infill"] = {
+                "pattern": pattern,
+                "density": thickness,
+            }
         summary = f"Added {thickness}mm {pattern} infill"
         # Return updated spec and summary, without LLM confirmation
         return spec, summary
 
     # Quick parse for simple boolean operations like "union", "difference", or "intersection"
     cmd = raw.lower()
-    if 'union' in cmd or 'difference' in cmd or 'intersection' in cmd:
+    if "union" in cmd or "difference" in cmd or "intersection" in cmd:
         # Determine operation
-        if 'union' in cmd:
-            op = 'union'
-        elif 'difference' in cmd:
-            op = 'difference'
+        if "union" in cmd:
+            op = "union"
+        elif "difference" in cmd:
+            op = "difference"
         else:
-            op = 'intersection'
+            op = "intersection"
         summary = f"Applied {op} operation to shapes"
         return spec, summary
     old_spec = spec
@@ -680,38 +750,41 @@ def update_request(sid: str, spec: list, raw: str):
     promoted = []
     for node in intermediate_spec:
         # Detect nested voronoi infill modifier
-        infill = node.get('modifiers', {}).get('infill')
-        if isinstance(infill, dict) and infill.get('pattern') == 'voronoi':
+        infill = node.get("modifiers", {}).get("infill")
+        if isinstance(infill, dict) and infill.get("pattern") == "voronoi":
             # Compute defaults based on the primitive's bounding box
-            prim_dict = node['primitive']
+            prim_dict = node["primitive"]
             shape, params = next(iter(prim_dict.items()))
             bbox_min, bbox_max = _compute_bbox_from_primitive({shape: params})
             size = [bbox_max[i] - bbox_min[i] for i in range(3)]
-            infill.setdefault('min_dist', max(size) / 20.0)
-            infill.setdefault('wall_thickness', size[2] / 50.0)
-            infill.setdefault('bbox_min', list(bbox_min))
-            infill.setdefault('bbox_max', list(bbox_max))
-            infill.setdefault('uniform', True)
-            infill.setdefault('adaptive', True)
-            infill.setdefault('max_depth', 3)
-            infill.setdefault('threshold', 0.1)
-            infill.setdefault('resolution', [32, 32, 32])
-            infill.setdefault('shell_offset', 0.0)
-            infill.setdefault('auto_cap', False)
+            infill.setdefault("min_dist", max(size) / 20.0)
+            infill.setdefault("wall_thickness", size[2] / 50.0)
+            infill.setdefault("bbox_min", list(bbox_min))
+            infill.setdefault("bbox_max", list(bbox_max))
+            infill.setdefault("uniform", True)
+            infill.setdefault("adaptive", True)
+            infill.setdefault("max_depth", 3)
+            infill.setdefault("threshold", 0.1)
+            infill.setdefault("resolution", [32, 32, 32])
+            infill.setdefault("shell_offset", 0.0)
+            infill.setdefault("auto_cap", False)
             # always regenerate seed points, and expose num_points parameter
-            uniform = _parse_bool(infill.get('uniform', True))
-            infill['uniform'] = uniform
-            seeds = rust_primitives.sample_inside(node['primitive'], infill['min_dist'])
+            uniform = _parse_bool(infill.get("uniform", True))
+            infill["uniform"] = uniform
+            seeds = rust_primitives.sample_inside(node["primitive"], infill["min_dist"])
             if len(seeds) > MAX_SEED_POINTS:
                 seeds = seeds[:MAX_SEED_POINTS]
             # expose a tunable count parameter for seed generation
-            infill.setdefault('num_points', len(seeds))
-            if 'num_points' in infill:
+            infill.setdefault("num_points", min(len(seeds), DEFAULT_SEED_POINTS))
+            if "num_points" in infill:
                 import random
+
                 random.shuffle(seeds)
-                seeds = seeds[: int(infill['num_points'])]
-            infill['seed_points'] = seeds
-            logging.debug(f"update_request: generated {len(infill['seed_points'])} seed points for {shape}")
+                seeds = seeds[: int(infill["num_points"])]
+            infill["seed_points"] = seeds
+            logging.debug(
+                f"update_request: generated {len(infill['seed_points'])} seed points for {shape}"
+            )
         promoted.append(node)
     new_spec = promoted
     new_summary = generate_summary(new_spec)

--- a/tests/ai_adapter/test_default_seed_points.py
+++ b/tests/ai_adapter/test_default_seed_points.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ai_adapter import csg_adapter
+
+
+def _make_seeds(n):
+    return [(float(i), 0.0, 0.0) for i in range(n)]
+
+
+def test_interpret_llm_request_uses_default_seed_points(monkeypatch):
+    # Arrange: stub seed sampler to return many points
+    monkeypatch.setattr(
+        csg_adapter.rust_primitives,
+        "sample_inside",
+        lambda shape, min_dist: _make_seeds(csg_adapter.DEFAULT_SEED_POINTS + 500),
+    )
+    spec = {"shape": "cube", "size_mm": 20, "infill": {"pattern": "voronoi"}}
+
+    # Act
+    result = csg_adapter.interpret_llm_request(spec)
+    infill = result["primitives"][0]["modifiers"]["infill"]
+
+    # Assert
+    assert infill["num_points"] == csg_adapter.DEFAULT_SEED_POINTS
+    assert len(infill["seed_points"]) == csg_adapter.DEFAULT_SEED_POINTS
+
+
+def test_update_request_uses_default_seed_points(monkeypatch):
+    # Arrange: stub sampler and review_request
+    monkeypatch.setattr(
+        csg_adapter.rust_primitives,
+        "sample_inside",
+        lambda shape, min_dist: _make_seeds(csg_adapter.DEFAULT_SEED_POINTS + 500),
+    )
+    monkeypatch.setattr(csg_adapter, "review_request", lambda data: (data["spec"], ""))
+    spec = [
+        {
+            "primitive": {"cube": {"size": 20}},
+            "modifiers": {"infill": {"pattern": "voronoi"}},
+        }
+    ]
+
+    # Act
+    new_spec, _ = csg_adapter.update_request("sid", spec, "raw")
+    infill = new_spec[0]["modifiers"]["infill"]
+
+    # Assert
+    assert infill["num_points"] == csg_adapter.DEFAULT_SEED_POINTS
+    assert len(infill["seed_points"]) == csg_adapter.DEFAULT_SEED_POINTS


### PR DESCRIPTION
## Summary
- Add `DEFAULT_SEED_POINTS = 1000` constant and apply it when deriving seed counts
- Limit `interpret_llm_request` and `update_request` to use at most the default when `num_points` is omitted
- Test that seed generation clamps to `DEFAULT_SEED_POINTS`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8bd833e108326843e088179c84661