### PR TITLE
Honor provided seed points and num_points in hex lattice generation

### DIFF
--- a/core_engine/core_engine.py
+++ b/core_engine/core_engine.py
@@ -1,0 +1,49 @@
+"""Lightweight Python stub for the Rust-backed ``core_engine`` module.
+
+This stub implements only the minimal surface area required by the tests.
+It provides naive Python implementations of ``prune_adjacency_via_grid`` and
+placeholders for other symbols expected by the real module.  The functions are
+not optimized and should only be used in test environments where the compiled
+extension is unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+
+def prune_adjacency_via_grid(
+    points: Sequence[Tuple[float, float, float]], spacing: float
+) -> List[Tuple[int, int]]:
+    """Return index pairs for seeds within ``spacing`` distance.
+
+    This naive implementation performs an ``O(n^2)`` scan which is sufficient
+    for the small point sets used in tests.
+    """
+
+    adj: List[Tuple[int, int]] = []
+    thresh = spacing * spacing
+    for i, p in enumerate(points):
+        for j in range(i + 1, len(points)):
+            q = points[j]
+            dx = p[0] - q[0]
+            dy = p[1] - q[1]
+            dz = p[2] - q[2]
+            if dx * dx + dy * dy + dz * dz <= thresh:
+                adj.append((i, j))
+    return adj
+
+
+@dataclass
+class OctreeNode:  # pragma: no cover - placeholder for API compatibility
+    pass
+
+
+def generate_adaptive_grid(*args, **kwargs):  # pragma: no cover - stub
+    return []
+
+
+def compute_uniform_cells(*args, **kwargs):  # pragma: no cover - stub
+    return {}, []
+

--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -86,6 +86,7 @@ def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
         "bbox_min",
         "bbox_max",
         "seed_points",
+        "num_points",
         "use_voronoi_edges",
         "_is_voronoi",
         "uniform",
@@ -122,6 +123,9 @@ def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
     plane_normal = spec.get("plane_normal") or [0.0, 0.0, 1.0]
     max_distance = spec.get("max_distance")
 
+    seeds = spec.get("seed_points")
+    num_points = spec.get("num_points")
+
     lattice_kwargs = {
         "return_cells": True,
         "use_voronoi_edges": use_voronoi_edges,
@@ -135,6 +139,12 @@ def generate_hex_lattice(spec: Dict[str, Any]) -> Dict[str, Any]:
                 "max_distance": max_distance,
             }
         )
+
+    if seeds is not None:
+        lattice_kwargs["seeds"] = seeds
+        num_points = num_points or len(seeds)
+    if num_points is not None:
+        lattice_kwargs["num_points"] = int(num_points)
 
     seed_pts, cell_vertices, edge_list, cells = build_hex_lattice(
         bbox_min,

--- a/tests/design_api/test_hex_lattice_seeds.py
+++ b/tests/design_api/test_hex_lattice_seeds.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from design_api.services.infill_service import generate_hex_lattice
+
+
+def test_forwarded_seed_points_used_verbatim():
+    seeds = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+    spec = {
+        "bbox_min": [-1.0, -1.0, -1.0],
+        "bbox_max": [1.0, 1.0, 1.0],
+        "spacing": 0.5,
+        "seed_points": seeds,
+        "mode": "organic",
+    }
+
+    res = generate_hex_lattice(spec)
+    out = res.get("seed_points")
+
+    assert len(out) == len(seeds)
+    assert all(np.allclose(a, b) for a, b in zip(seeds, out))
+
+
+def test_num_points_limits_generated_seeds():
+    spec = {
+        "bbox_min": [0.0, 0.0, 0.0],
+        "bbox_max": [2.0, 2.0, 2.0],
+        "spacing": 0.5,
+        "num_points": 5,
+        "primitive": {},
+        "mode": "organic",
+    }
+
+    res = generate_hex_lattice(spec)
+    seeds = res.get("seed_points", [])
+
+    assert len(seeds) == 5


### PR DESCRIPTION
## Summary
- Respect provided `seed_points` in `generate_hex_lattice` and forward them and `num_points` to the lattice builder
- Extend `build_hex_lattice` to accept external seeds and clamp to `num_points`
- Add lightweight `core_engine` stub and tests verifying seed forwarding and `num_points` limits

## Testing
- `pytest tests/design_api -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0c73cd08326836b6b87991ff423