### PR TITLE
Ensure core_engine module exposes sample_inside

### DIFF
--- a/ai_adapter/rust_primitives.py
+++ b/ai_adapter/rust_primitives.py
@@ -25,7 +25,8 @@ def _load_core_engine() -> ModuleType:
     if spec and spec.loader:
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        return module
+        if hasattr(module, "sample_inside"):
+            return module
 
     crate_dir = pathlib.Path(__file__).resolve().parents[1] / "core_engine"
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- Verify core_engine module exposes `sample_inside` after import
- Rebuild Rust extension if attribute missing and reload module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8d252f3948326806e0fca2ea6db8c