### PR TITLE
refactor: unify Voronoi seed limit

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -6,11 +6,10 @@ from ai_adapter.schema.implicitus_pb2 import Model
 import uuid
 from google.protobuf import json_format
 from ai_adapter import rust_primitives
+from implicitus.constants import MAX_VORONOI_SEEDS
 
-# Maximum number of voronoi seed points to avoid huge arrays
-MAX_SEED_POINTS = 7500
 # Default number of voronoi seed points when unspecified
-DEFAULT_SEED_POINTS = 1000
+DEFAULT_SEED_POINTS = MAX_VORONOI_SEEDS // 10
 
 # --- Helper functions for voronoi seed generation ---
 import random
@@ -437,8 +436,8 @@ def interpret_llm_request(llm_output):
                     seeds = rust_primitives.sample_inside(
                         node["primitive"], infill["min_dist"]
                     )
-                    if len(seeds) > MAX_SEED_POINTS:
-                        seeds = seeds[:MAX_SEED_POINTS]
+                    if len(seeds) > MAX_VORONOI_SEEDS:
+                        seeds = seeds[:MAX_VORONOI_SEEDS]
                     infill.setdefault(
                         "num_points", min(len(seeds), DEFAULT_SEED_POINTS)
                     )
@@ -527,8 +526,8 @@ def interpret_llm_request(llm_output):
                 seeds = rust_primitives.sample_inside(
                     node["primitive"], infill["min_dist"]
                 )
-                if len(seeds) > MAX_SEED_POINTS:
-                    seeds = seeds[:MAX_SEED_POINTS]
+                if len(seeds) > MAX_VORONOI_SEEDS:
+                    seeds = seeds[:MAX_VORONOI_SEEDS]
                 infill.setdefault("num_points", min(len(seeds), DEFAULT_SEED_POINTS))
                 if "num_points" in infill:
                     import random
@@ -772,8 +771,8 @@ def update_request(sid: str, spec: list, raw: str):
             uniform = _parse_bool(infill.get("uniform", True))
             infill["uniform"] = uniform
             seeds = rust_primitives.sample_inside(node["primitive"], infill["min_dist"])
-            if len(seeds) > MAX_SEED_POINTS:
-                seeds = seeds[:MAX_SEED_POINTS]
+            if len(seeds) > MAX_VORONOI_SEEDS:
+                seeds = seeds[:MAX_VORONOI_SEEDS]
             # expose a tunable count parameter for seed generation
             infill.setdefault("num_points", min(len(seeds), DEFAULT_SEED_POINTS))
             if "num_points" in infill:

--- a/constants.json
+++ b/constants.json
@@ -1,0 +1,3 @@
+{
+  "MAX_VORONOI_SEEDS": 10000
+}

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,8 @@
+import json
+from pathlib import Path
+
+_constants_path = Path(__file__).with_name("constants.json")
+with _constants_path.open(encoding="utf-8") as f:
+    _cfg = json.load(f)
+
+MAX_VORONOI_SEEDS: int = int(_cfg["MAX_VORONOI_SEEDS"])

--- a/core_engine/Cargo.toml
+++ b/core_engine/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [build-dependencies]
 prost-build = "0.11"
 pyo3-build-config = { version = "0.22", features = ["resolve-config"] }
+serde_json = "1.0"
 
 [dependencies]
 prost = "0.11"

--- a/core_engine/build.rs
+++ b/core_engine/build.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::fs;
 
 fn main() {
     pyo3_build_config::use_pyo3_cfgs();
@@ -29,4 +30,14 @@ fn main() {
     config
         .compile_protos(&[proto_file], &[proto_dir])
         .expect("Failed to compile protobufs");
+
+    // Generate Rust constants from shared configuration
+    let constants_path = manifest_dir.parent().unwrap().join("constants.json");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let dest = out_dir.join("constants.rs");
+    let data = fs::read_to_string(constants_path).expect("read constants.json");
+    let value: serde_json::Value = serde_json::from_str(&data).expect("parse constants.json");
+    let max = value["MAX_VORONOI_SEEDS"].as_u64().expect("MAX_VORONOI_SEEDS");
+    fs::write(dest, format!("pub const MAX_VORONOI_SEEDS: usize = {};", max))
+        .expect("write constants.rs");
 }

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -17,10 +17,9 @@ pub mod spatial;
 pub mod uniform;
 pub mod voronoi;
 
-/// Maximum number of seed points to consider when constructing a Voronoi mesh.
-/// With adjacency pruning the algorithm scales to thousands of points, so this
-/// limit is mostly a safeguard against extreme inputs.
-pub const MAX_VORONOI_SEEDS: usize = 10_000;
+// This constant is generated at build time from `constants.json` to ensure
+// that all language layers share the same value.
+include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
 // A very basic SDF evaluator that handles a few primitive shapes.
 pub fn evaluate_sdf(model: &Model, x: f64, y: f64, z: f64) -> f64 {

--- a/core_engine/src/primitives/mod.rs
+++ b/core_engine/src/primitives/mod.rs
@@ -3,8 +3,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyDictMethods};
 
-const MAX_SEED_POINTS: usize = 7500;
-
 fn get_f64(dict: &Bound<PyDict>, key: &str) -> Option<f64> {
     dict
         .get_item(key)
@@ -104,7 +102,7 @@ pub fn sample_inside(shape_spec: &Bound<PyDict>, spacing: f64) -> PyResult<Vec<(
                 let z = bbox_min.2 + iz as f64 * spacing;
                 if point_inside(&shape, &params, x, y, z) {
                     seeds.push((x, y, z));
-                    if seeds.len() >= MAX_SEED_POINTS {
+                    if seeds.len() >= crate::MAX_VORONOI_SEEDS {
                         return Ok(seeds);
                     }
                 }

--- a/implicitus-ui/src/components/VoronoiMaterial.tsx
+++ b/implicitus-ui/src/components/VoronoiMaterial.tsx
@@ -1,8 +1,9 @@
 import * as THREE from 'three';
 import { shaderMaterial } from '@react-three/drei';
 import { extend } from '@react-three/fiber';
+import config from '../constants.json';
 
-const MAX_SEEDS = 512;
+const MAX_SEEDS = config.MAX_VORONOI_SEEDS;
 const texSize = Math.ceil(Math.sqrt(MAX_SEEDS));
 const GRID_CELL_CAPACITY = 8;
 const GRID_TEX_HEIGHT = Math.ceil(GRID_CELL_CAPACITY / 4);

--- a/implicitus-ui/src/components/VoronoiMesh.tsx
+++ b/implicitus-ui/src/components/VoronoiMesh.tsx
@@ -2,10 +2,11 @@ import React, { useMemo, useEffect } from 'react';
 import * as THREE from 'three';
 import { useFrame, useThree } from '@react-three/fiber';
 import { VoronoiMaterial } from './VoronoiMaterial';
+import config from '../constants.json';
 
 const DEBUG = false;
 
-const MAX_SEEDS = 512;
+const MAX_VORONOI_SEEDS = config.MAX_VORONOI_SEEDS;
 const GRID_CELL_CAPACITY = 8;
 const GRID_TEX_HEIGHT = Math.ceil(GRID_CELL_CAPACITY / 4);
 const CELL_SIZE_FACTOR = 1.5; // Tunable factor balancing lookup vs iteration
@@ -65,7 +66,7 @@ const VoronoiMesh: React.FC<VoronoiMeshProps> = ({
     : Math.min(maxX - minX, maxY - minY, maxZ - minZ) / 2;
 
   const numSeeds = seedPoints.length;
-  const count = Math.min(MAX_SEEDS, numSeeds);
+  const count = Math.min(MAX_VORONOI_SEEDS, numSeeds);
   const texSize = Math.max(1, Math.ceil(Math.sqrt(count)));
   const seedsArray = useMemo(() => new Float32Array(seedPoints.flat()), [seedPoints]);
   const texData = useMemo(() => new Float32Array(texSize * texSize * 4), [texSize]);

--- a/implicitus-ui/src/constants.json
+++ b/implicitus-ui/src/constants.json
@@ -1,0 +1,1 @@
+../../constants.json

--- a/implicitus-ui/tsconfig.app.json
+++ b/implicitus-ui/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- centralize MAX_VORONOI_SEEDS in shared config and use across Python, Rust and UI
- generate Rust constant from shared JSON
- allow TS to import shared constant

## Testing
- `pytest`
- `cargo test`
- `npm test` *(fails: design_api server did not start)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc65f8fc832692bd17cadda8591e