### PR TITLE
Fix slicer_server warnings

### DIFF
--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -30,7 +30,7 @@ pub struct SliceResponse {
 
 #[derive(Deserialize)]
 struct VoronoiRequest {
-    seeds: Vec<(f64, f64, f64)>,
+    _seeds: Vec<(f64, f64, f64)>,
 }
 
 #[derive(Serialize, Clone)]
@@ -38,11 +38,6 @@ struct VoronoiResponse {
     status: &'static str,
     vertices: Vec<(f64, f64, f64)>,
     edges: Vec<(usize, usize)>,
-}
-
-#[derive(Serialize)]
-struct JobResponse {
-    job_id: String,
 }
 
 type JobMap = Arc<Mutex<HashMap<String, Option<VoronoiResponse>>>>;


### PR DESCRIPTION
## Summary
- silence unused `seeds` field in `VoronoiRequest`
- remove unused `JobResponse` struct

## Testing
- `cargo check --bin slicer_server`
- `cargo test`
- `pytest` *(fails: IndentationError in ai_adapter/csg_adapter.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b90ffe04a8832693a12f2afbc1a1ae