### PR TITLE
Infer hex lattice spacing from seed count

### DIFF
--- a/docs/mesh_generation.md
+++ b/docs/mesh_generation.md
@@ -13,6 +13,9 @@ both primitive solids and infill structures.
 ## Infills
 
 * Accept seed points and bounds describing the infill region.
+* When only a seed count is provided, the lattice spacing is estimated from the
+  bounding‑box volume so that fewer seeds produce a coarser pattern. Explicit
+  `spacing` or `min_dist` values override this behavior.
 * Construct Voronoi or lattice cells, yielding explicit vertex coordinates.
 * Produce edge connectivity so downstream tools can build struts or surfaces.
 


### PR DESCRIPTION
## Summary
- derive lattice spacing from bounding-box volume when only `num_points` is specified
- document relationship between `spacing` and `num_points`
- test spacing inference logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e82368d8832698c50f0be916eec2