### PR TITLE
Add seed configuration to mesh endpoint

### DIFF
--- a/tests/design_api/test_mesh_endpoint.py
+++ b/tests/design_api/test_mesh_endpoint.py
@@ -4,7 +4,12 @@ from design_api.main import app
 def test_mesh_endpoint_returns_data():
     client = TestClient(app)
     seeds = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
-    resp = client.post('/design/mesh', json={'seed_points': seeds})
+    payload = {
+        'seed_points': seeds,
+        'num_points': len(seeds),
+        'mode': 'organic',
+    }
+    resp = client.post('/design/mesh', json=payload)
     assert resp.status_code == 200
     data = resp.json()
     assert 'vertices' in data and 'edges' in data


### PR DESCRIPTION
## Summary
- allow MeshRequest to specify `num_points` and `mode`
- derive mesh seed config using `resolve_seed_spec`
- extend mesh endpoint test to cover new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba0221e87c832691e223bac5b95e63