### PR TITLE
Add seed default tests for hex lattice

### DIFF
--- a/tests/design_api/test_seed_defaults.py
+++ b/tests/design_api/test_seed_defaults.py
@@ -1,0 +1,91 @@
+import numpy as np
+import random
+import pytest
+
+from design_api.services.infill_service import generate_hex_lattice
+from constants import DEFAULT_VORONOI_SEEDS
+
+
+@pytest.fixture(autouse=True)
+def fake_lattice(monkeypatch):
+    """Stub out ``build_hex_lattice`` with a lightweight Python version."""
+
+    def _fake_build_hex_lattice(
+        bbox_min,
+        bbox_max,
+        spacing,
+        primitive,
+        seeds=None,
+        num_points=None,
+        mode="uniform",
+        random_seed=None,
+        **_,
+    ):
+        if seeds is not None:
+            pts = [list(p) for p in seeds]
+        elif mode == "uniform":
+            count = int(num_points or 0)
+            side = max(int(round(count ** (1.0 / 3.0))), 1)
+            pts = []
+            for i in range(count):
+                x_idx = i % side
+                y_idx = (i // side) % side
+                z_idx = i // (side * side)
+                pts.append(
+                    [
+                        bbox_min[0] + x_idx * spacing,
+                        bbox_min[1] + y_idx * spacing,
+                        bbox_min[2] + z_idx * spacing,
+                    ]
+                )
+        else:  # organic
+            rng = random.Random(random_seed)
+            pts = [
+                [rng.uniform(bbox_min[i], bbox_max[i]) for i in range(3)]
+                for _ in range(num_points or 0)
+            ]
+        return pts, [], [], []
+
+    monkeypatch.setattr(
+        "design_api.services.infill_service.build_hex_lattice", _fake_build_hex_lattice
+    )
+    monkeypatch.setattr(
+        "design_api.services.voronoi_gen.voronoi_gen.build_hex_lattice",
+        _fake_build_hex_lattice,
+    )
+    return _fake_build_hex_lattice
+
+
+def test_default_seed_count(fake_lattice):
+    spec = {"primitive": {"sphere": {"center": [0.0, 0.0, 0.0], "radius": 1.0}}}
+    res = generate_hex_lattice(spec)
+    seeds = res.get("seed_points", [])
+    assert len(seeds) == DEFAULT_VORONOI_SEEDS
+
+
+def test_organic_mode_randomized_seed_count(fake_lattice):
+    spec = {
+        "primitive": {"sphere": {"center": [0.0, 0.0, 0.0], "radius": 1.0}},
+        "mode": "organic",
+        "num_points": 25,
+    }
+    res1 = generate_hex_lattice(spec)
+    res2 = generate_hex_lattice(spec)
+    seeds1 = res1.get("seed_points", [])
+    seeds2 = res2.get("seed_points", [])
+    assert len(seeds1) == 25
+    assert len(seeds2) == 25
+    assert seeds1 != seeds2
+
+
+def test_seed_points_reused_verbatim(fake_lattice):
+    seeds = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+    spec = {
+        "primitive": {"sphere": {"center": [0.0, 0.0, 0.0], "radius": 1.0}},
+        "seed_points": seeds,
+        "mode": "organic",
+    }
+    res = generate_hex_lattice(spec)
+    out = res.get("seed_points")
+    assert len(out) == len(seeds)
+    assert all(np.allclose(a, b) for a, b in zip(seeds, out))


### PR DESCRIPTION
## Summary
- add tests verifying default Voronoi seed count
- confirm organic mode randomization and seed point reuse

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba044c87ec83269e328eb585a24852