### PR TITLE
Replace deprecated uniform flag with mode

### DIFF
--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -89,13 +89,6 @@ def generate_hex_lattice(
     """
 
     primitive = spec.get("primitive", {})
-    mode = spec.get("mode")
-    if mode is None:
-        uniform_flag = spec.get("uniform")
-        if isinstance(uniform_flag, str):
-            uniform_flag = uniform_flag.lower() == "true"
-        if uniform_flag is not None:
-            mode = "uniform" if uniform_flag else "organic"
 
     seed_cfg = resolve_seed_spec(
         primitive,
@@ -104,7 +97,8 @@ def generate_hex_lattice(
         seed_points=spec.get("seed_points"),
         num_points=spec.get("num_points"),
         spacing=spec.get("spacing") or spec.get("min_dist"),
-        mode=mode,
+        mode=spec.get("mode"),
+        uniform=spec.get("uniform"),
     )
 
     bbox_min = seed_cfg["bbox_min"]

--- a/design_api/services/seed_utils.py
+++ b/design_api/services/seed_utils.py
@@ -15,6 +15,7 @@ def resolve_seed_spec(
     num_points: Optional[int] = None,
     spacing: Optional[float] = None,
     mode: Optional[str] = None,
+    uniform: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Normalize seed generation parameters for lattice construction.
 
@@ -38,6 +39,9 @@ def resolve_seed_spec(
     mode:
         Sampling mode, either ``"organic"`` or ``"uniform"``. Defaults to
         ``"uniform"``.
+    uniform:
+        Deprecated boolean flag for uniform sampling. When supplied, ``mode`` is
+        derived from its value.
     """
 
     # Derive bounding box from the primitive when needed
@@ -49,6 +53,10 @@ def resolve_seed_spec(
             if bbox_max is None:
                 bbox_max = list(derived_max)
 
+    if mode is None and uniform is not None:
+        if isinstance(uniform, str):
+            uniform = uniform.lower() == "true"
+        mode = "uniform" if uniform else "organic"
     mode = mode or "uniform"
 
     if seed_points is not None:


### PR DESCRIPTION
## Summary
- normalize infill specs to use `mode` instead of legacy boolean `uniform`
- map incoming `uniform` values to `mode` via `resolve_seed_spec`
- propagate mode-based seed resolution through design API and infill service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba1d0a4a088326888db846254fe0e1