### PR TITLE
Add Voronoi infill parameters to slicer configuration

### DIFF
--- a/core_engine/tests/slice_model.rs
+++ b/core_engine/tests/slice_model.rs
@@ -28,6 +28,7 @@ fn slice_model_produces_segments() {
         ny: 3,
         seed_points: Vec::new(),
         infill_pattern: None,
+        wall_thickness: 0.0,
     };
 
     // Call the slice and verify it returns non-empty contours


### PR DESCRIPTION
## Summary
- extend `SliceConfig` with infill wall thickness and use seeds/patterns
- generate Voronoi-based infill edges and merge with primitive contours
- parse infill metadata in slicer server and adapt tests

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba2b5d47d88326a7e3342d63578551