### PR TITLE
Separate Voronoi infill segments from slice contours

### DIFF
--- a/core_engine/tests/box_slice.rs
+++ b/core_engine/tests/box_slice.rs
@@ -37,6 +37,7 @@ async fn slice_box_model_returns_square_contour() {
     let bytes = to_bytes(body).await.unwrap();
     let resp: SliceResponse = serde_json::from_slice(&bytes).unwrap();
     let contour = &resp.contours[0];
+    assert!(resp.segments.is_empty());
 
     // Verify contour bounds match the box dimensions
     let min_x = contour.iter().map(|p| p.0).fold(f64::INFINITY, f64::min);
@@ -78,5 +79,6 @@ async fn slice_returns_debug_for_invalid_model() {
 
     assert_eq!(resp.debug.seed_count, 1);
     assert!(resp.contours.is_empty());
+    assert!(resp.segments.is_empty());
 
 }

--- a/core_engine/tests/slice_model.rs
+++ b/core_engine/tests/slice_model.rs
@@ -31,8 +31,21 @@ fn slice_model_produces_segments() {
         wall_thickness: 0.0,
     };
 
-    // Call the slice and verify it returns non-empty contours
-    let contours = slice_model(&model, &config);
-    assert!(!contours.is_empty(), "Expected non-empty contours from slice_model, got {:?}", contours);
-    assert!(contours[0].len() >= 2, "Expected at least two points in a contour, got {:?}", contours[0]);
+    // Call the slice and verify it returns non-empty contours and no segments
+    let result = slice_model(&model, &config);
+    assert!(
+        !result.contours.is_empty(),
+        "Expected non-empty contours from slice_model, got {:?}",
+        result.contours
+    );
+    assert!(
+        result.contours[0].len() >= 2,
+        "Expected at least two points in a contour, got {:?}",
+        result.contours[0]
+    );
+    assert!(
+        result.segments.is_empty(),
+        "Expected no segments for sphere slice, got {:?}",
+        result.segments
+    );
 }

--- a/core_engine/tests/voronoi_slice.rs
+++ b/core_engine/tests/voronoi_slice.rs
@@ -41,17 +41,15 @@ fn voronoi_infill_slice_matches_expected() {
         wall_thickness: 0.0,
     };
 
-    let contours = slice_model(&model, &config);
-    assert!(!contours.is_empty());
-    // First contour should correspond to the Voronoi edge intersection at (1.1, 1.1)
-    let (cx, cy) = contours[0][0];
+    let result = slice_model(&model, &config);
+    assert!(!result.segments.is_empty());
+    // First segment should correspond to the Voronoi edge intersection at (1.1, 1.1)
+    let ((sx, sy), (ex, ey)) = result.segments[0];
     assert!(
-        approx(cx, 1.1) && approx(cy, 1.1),
-        "Expected intersection near (1.1,1.1), got {:?}",
-        contours[0][0]
+        approx(sx, 1.1) && approx(sy, 1.1),
+        "Expected intersection near (1.1,1.1), got ({:?}, {:?})",
+        sx,
+        sy
     );
-    assert_eq!(contours[0].len(), 2);
-    assert!(
-        approx(contours[0][0].0, contours[0][1].0) && approx(contours[0][0].1, contours[0][1].1)
-    );
+    assert!(approx(sx, ex) && approx(sy, ey));
 }


### PR DESCRIPTION
## Summary
- track Voronoi edge intersections as start/end segments instead of degenerate contour loops
- return both contours and segments from `slice_model` and expose segments via the slicer server
- adjust tests to assert segment endpoints

## Testing
- `cargo test --manifest-path core_engine/Cargo.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba57c7a32c8326a967f7fa1800cf31