### PR TITLE
Support lattice primitives in slicer infill parsing

### DIFF
--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -92,7 +92,7 @@ pub async fn handle_slice(req: SliceRequest) -> Result<impl warp::Reply, warp::R
     // Extract debug info before consuming the model value
     let debug = extract_debug_info(&req._model);
 
-    // Pull out infill data to forward to the slice configuration
+    // Pull out infill or lattice data to forward to the slice configuration
     let (seed_points, infill_pattern, wall_thickness) = parse_infill(&req._model);
 
     let config = SliceConfig {
@@ -181,6 +181,9 @@ fn parse_infill(value: &Value) -> (Vec<(f64, f64, f64)>, Option<String>, f64) {
         if let Some(obj) = v.as_object() {
             if let Some(infill) = obj.get("infill") {
                 return Some(infill);
+            }
+            if let Some(lattice) = obj.get("lattice") {
+                return Some(lattice);
             }
             for val in obj.values() {
                 if let Some(found) = find_infill(val) {

--- a/core_engine/tests/box_slice.rs
+++ b/core_engine/tests/box_slice.rs
@@ -1,9 +1,9 @@
 #[path = "../src/bin/slicer_server.rs"]
 mod slicer_server;
 
+use core_engine::implicitus::{node::Body, primitive::Shape, Box, Model, Node, Primitive, Vector3};
+use serde_json::{json, to_value};
 use slicer_server::{handle_slice, SliceRequest, SliceResponse};
-use core_engine::implicitus::{Model, Node, Primitive, Vector3, primitive::Shape, node::Body, Box};
-use serde_json::{to_value, json};
 use warp::hyper::body::to_bytes;
 use warp::Reply;
 
@@ -13,7 +13,13 @@ async fn slice_box_model_returns_square_contour() {
     let mut model = Model::default();
     model.id = "box".into();
 
-    let box_shape = Box { size: Some(Vector3 { x: 2.0, y: 2.0, z: 2.0 }) };
+    let box_shape = Box {
+        size: Some(Vector3 {
+            x: 2.0,
+            y: 2.0,
+            z: 2.0,
+        }),
+    };
     let mut prim = Primitive::default();
     prim.shape = Some(Shape::Box(box_shape));
 
@@ -41,9 +47,15 @@ async fn slice_box_model_returns_square_contour() {
 
     // Verify contour bounds match the box dimensions
     let min_x = contour.iter().map(|p| p.0).fold(f64::INFINITY, f64::min);
-    let max_x = contour.iter().map(|p| p.0).fold(f64::NEG_INFINITY, f64::max);
+    let max_x = contour
+        .iter()
+        .map(|p| p.0)
+        .fold(f64::NEG_INFINITY, f64::max);
     let min_y = contour.iter().map(|p| p.1).fold(f64::INFINITY, f64::min);
-    let max_y = contour.iter().map(|p| p.1).fold(f64::NEG_INFINITY, f64::max);
+    let max_y = contour
+        .iter()
+        .map(|p| p.1)
+        .fold(f64::NEG_INFINITY, f64::max);
 
     assert!((min_x + 1.0).abs() < 1e-6, "min_x was {}", min_x);
     assert!((max_x - 1.0).abs() < 1e-6, "max_x was {}", max_x);
@@ -53,7 +65,6 @@ async fn slice_box_model_returns_square_contour() {
     // Debug info should be present with zero seeds and no pattern
     assert_eq!(resp.debug.seed_count, 0);
     assert!(resp.debug.infill_pattern.is_none());
-
 }
 
 #[tokio::test]
@@ -80,5 +91,33 @@ async fn slice_returns_debug_for_invalid_model() {
     assert_eq!(resp.debug.seed_count, 1);
     assert!(resp.contours.is_empty());
     assert!(resp.segments.is_empty());
+}
 
+#[tokio::test]
+async fn slice_returns_debug_for_lattice_primitive() {
+    let req = SliceRequest {
+        _model: json!({
+            "primitive": {"lattice": {
+                "pattern": "voronoi",
+                "wall_thickness": 0.2,
+                "seed_points": [[0.0,0.0,0.0],[1.0,1.0,1.0]]
+            }}
+        }),
+        layer: 0.0,
+        x_min: None,
+        x_max: None,
+        y_min: None,
+        y_max: None,
+        nx: None,
+        ny: None,
+    };
+
+    let reply = handle_slice(req).await.unwrap();
+    let body = reply.into_response().into_body();
+    let bytes = to_bytes(body).await.unwrap();
+    let resp: SliceResponse = serde_json::from_slice(&bytes).unwrap();
+
+    assert_eq!(resp.debug.seed_count, 2);
+    assert!(resp.contours.is_empty());
+    assert!(resp.segments.is_empty());
 }


### PR DESCRIPTION
## Summary
- detect `lattice` blocks when parsing slicer infill configuration
- surface lattice seed data in slice debug info
- test lattice primitive parsing through slicer handler

## Testing
- `cargo test --test box_slice`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baefdb44248326abd531986d1da68a