### PR TITLE
Expose seed points in slicer debug

### DIFF
--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -28,6 +28,7 @@ pub struct SliceRequest {
 pub struct DebugInfo {
     pub seed_count: usize,
     pub infill_pattern: Option<String>,
+    pub seed_points: Option<Vec<(f64, f64, f64)>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -114,9 +115,16 @@ pub async fn handle_slice(req: SliceRequest) -> Result<impl warp::Reply, warp::R
         warn!("No seed points found for model ID {}", model_id);
     }
 
+    let debug_enabled = std::env::var("SLICER_DEBUG").map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
+
     let debug = DebugInfo {
         seed_count: seed_points.len(),
         infill_pattern: infill_pattern.clone(),
+        seed_points: if debug_enabled {
+            Some(seed_points.clone())
+        } else {
+            None
+        },
     };
 
     let config = SliceConfig {

--- a/core_engine/tests/box_slice.rs
+++ b/core_engine/tests/box_slice.rs
@@ -65,6 +65,7 @@ async fn slice_box_model_returns_square_contour() {
     // Debug info should be present with zero seeds and no pattern
     assert_eq!(resp.debug.seed_count, 0);
     assert!(resp.debug.infill_pattern.is_none());
+    assert!(resp.debug.seed_points.is_none());
 }
 
 #[tokio::test]
@@ -89,6 +90,7 @@ async fn slice_returns_debug_for_invalid_model() {
     let resp: SliceResponse = serde_json::from_slice(&bytes).unwrap();
 
     assert_eq!(resp.debug.seed_count, 1);
+    assert!(resp.debug.seed_points.is_none());
     assert!(resp.contours.is_empty());
     assert!(resp.segments.is_empty());
 }
@@ -118,6 +120,7 @@ async fn slice_returns_debug_for_lattice_primitive() {
     let resp: SliceResponse = serde_json::from_slice(&bytes).unwrap();
 
     assert_eq!(resp.debug.seed_count, 2);
+    assert!(resp.debug.seed_points.is_none());
     assert!(resp.contours.is_empty());
     assert!(resp.segments.is_empty());
 }

--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -70,9 +70,12 @@ function App() {
   const [spec, setSpec] = useState<any[]>([]);
   const [meshVertices, setMeshVertices] = useState<[number, number, number][]>([]);
   const [meshEdges, setMeshEdges] = useState<number[][]>([]);
-  // Seed points remain tied to the raw spec definition
+  const [sliceSeedPoints, setSliceSeedPoints] = useState<[number, number, number][]>([]);
+  // Seed points from slicer server take precedence if available
   const seedPoints: [number, number, number][] =
-    spec[0]?.modifiers?.infill?.seed_points ?? [];
+    sliceSeedPoints.length > 0
+      ? sliceSeedPoints
+      : spec[0]?.modifiers?.infill?.seed_points ?? [];
   const edges = meshEdges;
   // Reset mesh whenever the spec changes; geometry will be fetched separately.
   useEffect(() => {
@@ -130,7 +133,10 @@ function App() {
       if (data.debug) {
 
         console.log('[slicer_server] debug info:', data.debug);
-
+        if (Array.isArray(data.debug.seed_points)) {
+          setSliceSeedPoints(data.debug.seed_points);
+          console.log('[slicer_server] seed points:', data.debug.seed_points);
+        }
       }
     } catch (err) {
       console.error('[UI] slice fetch error:', err);


### PR DESCRIPTION
## Summary
- Include optional `seed_points` in slicer `DebugInfo` and expose when `SLICER_DEBUG` is set
- Record returned seed points in the UI for comparison with `design_api`
- Cover new debug field in existing slice tests

## Testing
- `cargo test`
- `pytest`
- `npm test` *(fails: tests/design_api_integration.test.tsx, tests/slicer_server_integration.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02105de483269502784f61cad295