### PR TITLE
Expose infill mode in slice configuration

### DIFF
--- a/core_engine/src/slice.rs
+++ b/core_engine/src/slice.rs
@@ -32,6 +32,7 @@ pub struct SliceConfig {
     pub seed_points: Vec<(f64, f64, f64)>,
     pub infill_pattern: Option<String>,
     pub wall_thickness: f64,
+    pub mode: Option<String>,
 }
 
 /// Placeholder marching squares edge table: for each case index, list of edge pairs.

--- a/core_engine/tests/multi_infill_slice.rs
+++ b/core_engine/tests/multi_infill_slice.rs
@@ -28,7 +28,7 @@ fn seeds_from_multiple_blocks_affect_slice() {
         }
     });
 
-    let (seeds, pattern, _) = slicer_server::parse_infill(&model_json);
+    let (seeds, pattern, _, _) = slicer_server::parse_infill(&model_json);
     assert_eq!(seeds.len(), 5);
     assert_eq!(pattern.as_deref(), Some("voronoi"));
 
@@ -53,6 +53,7 @@ fn seeds_from_multiple_blocks_affect_slice() {
         seed_points: seeds,
         infill_pattern: pattern,
         wall_thickness: 0.0,
+        mode: None,
     };
 
     let result = slice_model(&model, &config);

--- a/core_engine/tests/seed_patterns_slice.rs
+++ b/core_engine/tests/seed_patterns_slice.rs
@@ -41,6 +41,7 @@ fn voronoi_custom_seeds_modify_segments() {
         seed_points: seeds,
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.0,
+        mode: None,
     };
 
     let r1 = slice_model(&model, &cfg(seeds_a));
@@ -68,6 +69,7 @@ fn hex_custom_seeds_modify_segments() {
         seed_points: seeds,
         infill_pattern: Some("hex".into()),
         wall_thickness: 0.0,
+        mode: None,
     };
 
     let r1 = slice_model(&model, &cfg(seeds_a));

--- a/core_engine/tests/slice_model.rs
+++ b/core_engine/tests/slice_model.rs
@@ -1,7 +1,7 @@
 // core_engine/tests/slice_model.rs
 
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
 use core_engine::slice::{slice_model, SliceConfig};
-use core_engine::implicitus::{Model, Node, Primitive, Sphere, primitive::Shape, node::Body};
 
 #[test]
 fn slice_model_produces_segments() {
@@ -29,6 +29,7 @@ fn slice_model_produces_segments() {
         seed_points: Vec::new(),
         infill_pattern: None,
         wall_thickness: 0.0,
+        mode: None,
     };
 
     // Call the slice and verify it returns non-empty contours and no segments

--- a/core_engine/tests/voronoi_slice.rs
+++ b/core_engine/tests/voronoi_slice.rs
@@ -39,6 +39,7 @@ fn voronoi_infill_slice_matches_expected() {
         seed_points: seeds,
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.0,
+        mode: None,
     };
 
     let result = slice_model(&model, &config);

--- a/core_engine/tests/wall_thickness_slice.rs
+++ b/core_engine/tests/wall_thickness_slice.rs
@@ -32,6 +32,7 @@ fn wall_thickness_shifts_contours() {
         seed_points: seeds,
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.5,
+        mode: None,
     };
 
     let thin = slice_model(&model, &config);


### PR DESCRIPTION
## Summary
- capture optional `mode` from model infill blocks
- carry `mode` through `SliceConfig`
- update tests for new `SliceConfig` field

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb32961b9883268d2018e430985f95