### PR TITLE
Add uniform Voronoi infill SDF support

### DIFF
--- a/core_engine/Cargo.toml
+++ b/core_engine/Cargo.toml
@@ -25,6 +25,7 @@ pyo3 = { version = "0.22", features = ["abi3-py39"] }
 kiddo = "5.2"
 log = "0.4"
 env_logger = "0.11"
+once_cell = "1.18"
 
 [features]
 default = []

--- a/core_engine/src/slice.rs
+++ b/core_engine/src/slice.rs
@@ -236,6 +236,7 @@ pub fn slice_model(model: &Model, config: &SliceConfig) -> SliceResult {
                 config.infill_pattern.as_deref(),
                 &config.seed_points,
                 config.wall_thickness,
+                config.mode.as_deref(),
             );
         }
     }

--- a/core_engine/tests/sphere_sdf.rs
+++ b/core_engine/tests/sphere_sdf.rs
@@ -20,7 +20,7 @@ fn sphere_sdf() {
     model.root = Some(node);
 
     // At the center, SDF = -radius
-    let val = evaluate_sdf(&model, 0.0, 0.0, 0.0, None, &[], 0.0);
+    let val = evaluate_sdf(&model, 0.0, 0.0, 0.0, None, &[], 0.0, None);
     assert!(
         (val + 2.0).abs() < 1e-6,
         "Expected SDF at center to be -2.0, got {}",
@@ -28,7 +28,7 @@ fn sphere_sdf() {
     );
 
     // On the surface, SDF ~ 0
-    let val2 = evaluate_sdf(&model, 2.0, 0.0, 0.0, None, &[], 0.0);
+    let val2 = evaluate_sdf(&model, 2.0, 0.0, 0.0, None, &[], 0.0, None);
     assert!(
         val2.abs() < 1e-6,
         "Expected SDF at surface to be ~0, got {}",

--- a/core_engine/tests/voronoi_infill.rs
+++ b/core_engine/tests/voronoi_infill.rs
@@ -14,7 +14,7 @@ fn voronoi_infill_creates_voids() {
     model.root = Some(node);
 
     let seeds = vec![(1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)];
-    let val = evaluate_sdf(&model, 0.25, 0.0, 0.0, Some("voronoi"), &seeds, 0.0);
+    let val = evaluate_sdf(&model, 0.25, 0.0, 0.0, Some("voronoi"), &seeds, 0.0, None);
     assert!(
         val > 0.0,
         "Expected positive SDF inside Voronoi void, got {}",

--- a/core_engine/tests/voronoi_uniform_infill.rs
+++ b/core_engine/tests/voronoi_uniform_infill.rs
@@ -1,0 +1,50 @@
+use core_engine::evaluate_sdf;
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use std::path::Path;
+use std::sync::Once;
+
+fn init_python() {
+    static START: Once = Once::new();
+    START.call_once(|| {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let sys = py.import_bound("sys").unwrap();
+            let path = sys
+                .getattr("path")
+                .unwrap()
+                .downcast::<PyList>()
+                .unwrap()
+                .clone();
+            let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+            path.insert(0, repo_root.to_str().unwrap()).unwrap();
+        });
+    });
+}
+
+#[test]
+fn voronoi_uniform_infill_returns_positive() {
+    init_python();
+    let mut model = Model::default();
+    model.id = "voronoi_uniform".into();
+    let sphere = Sphere { radius: 2.0 };
+    let mut prim = Primitive::default();
+    prim.shape = Some(Shape::Sphere(sphere));
+    let mut node = Node::default();
+    node.body = Some(Body::Primitive(prim));
+    model.root = Some(node);
+
+    let seeds = vec![(0.0, 0.0, 0.0), (0.1, 0.0, 0.0)];
+    let val = evaluate_sdf(
+        &model,
+        0.0,
+        0.0,
+        0.0,
+        Some("voronoi"),
+        &seeds,
+        0.0,
+        Some("uniform"),
+    );
+    assert!(val.is_finite());
+}

--- a/core_engine/tests/voronoi_wall_thickness.rs
+++ b/core_engine/tests/voronoi_wall_thickness.rs
@@ -25,6 +25,7 @@ fn sphere_boundary_intact_with_voronoi_walls() {
         Some("voronoi"),
         &seeds,
         wall_thickness,
+        None,
     );
     assert!(
         surface.abs() < 1e-6,
@@ -41,6 +42,7 @@ fn sphere_boundary_intact_with_voronoi_walls() {
         Some("voronoi"),
         &seeds,
         wall_thickness,
+        None,
     );
     assert!(
         wall > 0.0,


### PR DESCRIPTION
## Summary
- Support uniform Voronoi infill by computing/caching hexagon polygons and returning distance to nearest edge
- Allow `evaluate_sdf` to accept sampling mode and propagate through slicing
- Add test covering uniform Voronoi infill

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c6a4d148326897e935a7742f409