### PR TITLE
test: add uniform voronoi coverage

### DIFF
--- a/core_engine/tests/multi_infill_slice.rs
+++ b/core_engine/tests/multi_infill_slice.rs
@@ -15,10 +15,12 @@ fn seeds_from_multiple_blocks_affect_slice() {
     let model_json = json!({
         "infill": {
             "pattern": "voronoi",
+            "mode": "uniform",
             "seed_points": [[0.0,0.0,0.0],[2.0,0.0,0.0]]
         },
         "extra": {
             "lattice": {
+                "mode": "uniform",
                 "seed_points": [
                     [0.0,2.0,0.0],
                     [0.0,0.0,2.0],
@@ -28,9 +30,10 @@ fn seeds_from_multiple_blocks_affect_slice() {
         }
     });
 
-    let (seeds, pattern, _, _) = slicer_server::parse_infill(&model_json);
+    let (seeds, pattern, _, mode) = slicer_server::parse_infill(&model_json);
     assert_eq!(seeds.len(), 5);
     assert_eq!(pattern.as_deref(), Some("voronoi"));
+    assert_eq!(mode.as_deref(), Some("uniform"));
 
     // Basic spherical model
     let mut model = Model::default();

--- a/core_engine/tests/voronoi_uniform_sdf.rs
+++ b/core_engine/tests/voronoi_uniform_sdf.rs
@@ -1,0 +1,100 @@
+use core_engine::core_engine as pymodule;
+use core_engine::evaluate_sdf;
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use std::path::Path;
+use std::sync::Once;
+
+fn init_python() {
+    static START: Once = Once::new();
+    START.call_once(|| {
+        pyo3::append_to_inittab!(pymodule);
+    });
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let sys = py.import_bound("sys").unwrap();
+        let sys_path = sys.getattr("path").unwrap();
+        let path = sys_path.downcast::<PyList>().unwrap();
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        path.insert(0, repo_root.to_str().unwrap()).unwrap();
+    });
+}
+
+fn patch_hex_stubs(py: Python<'_>) {
+    let code = r#"
+import numpy as np
+
+def fake_medial_axis(mesh):
+    return np.zeros((0,3))
+
+def fake_trace_hexagon(seed, medial_points, plane, *args, **kwargs):
+    s = np.array(seed)
+    verts = np.array([
+        [s[0]+1.0, s[1]+0.0, s[2]-1.0],
+        [s[0]+0.5, s[1]+0.866, s[2]+1.0],
+        [s[0]-0.5, s[1]+0.866, s[2]-1.0],
+        [s[0]-1.0, s[1]+0.0, s[2]+1.0],
+        [s[0]-0.5, s[1]-0.866, s[2]-1.0],
+        [s[0]+0.5, s[1]-0.866, s[2]+1.0],
+    ])
+    return verts, False, verts
+"#;
+    let module = PyModule::from_code_bound(py, code, "stub.py", "stub").unwrap();
+    let construct = py
+        .import_bound("design_api.services.voronoi_gen.uniform.construct")
+        .unwrap();
+    construct
+        .setattr(
+            "compute_medial_axis",
+            module.getattr("fake_medial_axis").unwrap(),
+        )
+        .unwrap();
+    construct
+        .setattr(
+            "trace_hexagon",
+            module.getattr("fake_trace_hexagon").unwrap(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn evaluate_sdf_uniform_has_thicker_walls() {
+    init_python();
+    Python::with_gil(|py| patch_hex_stubs(py));
+
+    let mut model = Model::default();
+    model.id = "voronoi_uniform_sdf".into();
+    let sphere = Sphere { radius: 2.0 };
+    let mut prim = Primitive::default();
+    prim.shape = Some(Shape::Sphere(sphere));
+    let mut node = Node::default();
+    node.body = Some(Body::Primitive(prim));
+    model.root = Some(node);
+
+    let seeds = vec![(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)];
+    let point = (1.0, 0.0, 0.0);
+
+    let standard = evaluate_sdf(
+        &model,
+        point.0,
+        point.1,
+        point.2,
+        Some("voronoi"),
+        &seeds,
+        0.0,
+        None,
+    );
+    let uniform = evaluate_sdf(
+        &model,
+        point.0,
+        point.1,
+        point.2,
+        Some("voronoi"),
+        &seeds,
+        0.0,
+        Some("uniform"),
+    );
+
+    assert!(uniform > standard, "expected uniform mode to yield thicker walls");
+}

--- a/core_engine/tests/voronoi_uniform_slice.rs
+++ b/core_engine/tests/voronoi_uniform_slice.rs
@@ -1,0 +1,98 @@
+use core_engine::core_engine as pymodule;
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
+use core_engine::slice::{slice_model, SliceConfig};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use std::path::Path;
+use std::sync::Once;
+
+fn init_python() {
+    static START: Once = Once::new();
+    START.call_once(|| {
+        pyo3::append_to_inittab!(pymodule);
+    });
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let sys = py.import_bound("sys").unwrap();
+        let sys_path = sys.getattr("path").unwrap();
+        let path = sys_path.downcast::<PyList>().unwrap();
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        path.insert(0, repo_root.to_str().unwrap()).unwrap();
+    });
+}
+
+fn patch_hex_stubs(py: Python<'_>) {
+    let code = r#"
+import numpy as np
+
+def fake_medial_axis(mesh):
+    return np.zeros((0,3))
+
+def fake_trace_hexagon(seed, medial_points, plane, *args, **kwargs):
+    s = np.array(seed)
+    verts = np.array([
+        [s[0]+1.0, s[1]+0.0, s[2]-1.0],
+        [s[0]+0.5, s[1]+0.866, s[2]+1.0],
+        [s[0]-0.5, s[1]+0.866, s[2]-1.0],
+        [s[0]-1.0, s[1]+0.0, s[2]+1.0],
+        [s[0]-0.5, s[1]-0.866, s[2]-1.0],
+        [s[0]+0.5, s[1]-0.866, s[2]+1.0],
+    ])
+    return verts, False, verts
+"#;
+    let module = PyModule::from_code_bound(py, code, "stub.py", "stub").unwrap();
+    let construct = py
+        .import_bound("design_api.services.voronoi_gen.uniform.construct")
+        .unwrap();
+    construct
+        .setattr(
+            "compute_medial_axis",
+            module.getattr("fake_medial_axis").unwrap(),
+        )
+        .unwrap();
+    construct
+        .setattr(
+            "trace_hexagon",
+            module.getattr("fake_trace_hexagon").unwrap(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn slice_uniform_voronoi_produces_hex_segments() {
+    init_python();
+    Python::with_gil(|py| patch_hex_stubs(py));
+
+    let mut model = Model::default();
+    model.id = "uniform_hex".into();
+    let sphere = Sphere { radius: 2.0 };
+    let mut prim = Primitive::default();
+    prim.shape = Some(Shape::Sphere(sphere));
+    let mut node = Node::default();
+    node.body = Some(Body::Primitive(prim));
+    model.root = Some(node);
+
+    let seeds = vec![(0.0, 0.0, 0.0)];
+
+    let config = SliceConfig {
+        z: 0.0,
+        x_min: -2.0,
+        x_max: 2.0,
+        y_min: -2.0,
+        y_max: 2.0,
+        nx: 3,
+        ny: 3,
+        seed_points: seeds,
+        infill_pattern: Some("voronoi".into()),
+        wall_thickness: 0.0,
+        mode: Some("uniform".into()),
+    };
+
+    let result = slice_model(&model, &config);
+    assert_eq!(
+        result.segments.len(),
+        6,
+        "Expected 6 hexagonal segments, got {}",
+        result.segments.len()
+    );
+}

--- a/tests/design_api/test_seed_debug_patterns.py
+++ b/tests/design_api/test_seed_debug_patterns.py
@@ -41,6 +41,7 @@ def test_seed_debug_log_records_seeds(monkeypatch):
                     "seed_points": seeds,
                     "bbox_min": [0, 0, 0],
                     "bbox_max": [1, 1, 1],
+                    "mode": "organic",
                 }
             },
         }


### PR DESCRIPTION
## Summary
- add tests for uniform Voronoi slicing and SDF wall thickness
- include mode field in helper JSON used by tests
- ensure seed debug tests provide explicit mode

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb450d70248326b483d58ad6923e5a