### PR TITLE
Fix uniform mode mapping for Voronoi lattices

### DIFF
--- a/ai_adapter/csg_adapter.py
+++ b/ai_adapter/csg_adapter.py
@@ -231,6 +231,12 @@ def _build_modifier_dict(raw_spec: dict) -> dict:
     if 'thickness_mm' in infill_data:
         infill_data['density'] = infill_data.pop('thickness_mm')
 
+    # Translate new "mode" flag into legacy uniform boolean
+    mode = infill_data.get('mode')
+    if mode is not None:
+        # Expose uniform flag for downstream consumers while preserving mode
+        infill_data['uniform'] = str(mode).lower() == 'uniform'
+
     pattern = infill_data.get('pattern')
     # Mark Voronoi infill specially
     if pattern == 'voronoi':

--- a/design_api/main.py
+++ b/design_api/main.py
@@ -125,7 +125,11 @@ async def review(req: dict, sid: Optional[str] = None):
                 if seed_points and bbox_min and bbox_max:
                     pts_arr = np.asarray(seed_points)
                     try:
-                        if inf.get("uniform"):
+                        uniform_flag = inf.get("uniform") or (
+                            isinstance(inf.get("mode"), str) and inf.get("mode").lower() == "uniform"
+                        )
+                        if uniform_flag:
+                            inf["uniform"] = True  # ensure downstream components see flag
                             plane = np.array([0.0, 0.0, 1.0])
                             extent = np.linalg.norm(np.array(bbox_max) - np.array(bbox_min)) * 0.5
                             cells = compute_uniform_cells(

--- a/tests/ai_adapter/test_csg_adapter.py
+++ b/tests/ai_adapter/test_csg_adapter.py
@@ -248,6 +248,12 @@ def test_review_request_with_voronoi_infill():
     assert isinstance(summary, str)
     assert 'voronoi' in summary.lower()
 
+
+def test_parse_voronoi_infill_mode_uniform():
+    raw = '{"shape":"box","size_mm":10,"infill":{"pattern":"voronoi","mode":"uniform"}}'
+    spec = parse_raw_spec(raw)
+    assert spec[0]['modifiers']['infill'].get('uniform') is True
+
 def test_update_request_seed_generation_count():
     # Ensure update_request caps seed points to MAX_SEED_POINTS
     raw = '{"shape":"sphere","size_mm":10}'

--- a/tests/design_api/test_review_uniform.py
+++ b/tests/design_api/test_review_uniform.py
@@ -40,7 +40,7 @@ async def test_review_generates_uniform_cells(monkeypatch):
         "modifiers": {
             "infill": {
                 "pattern": "voronoi",
-                "uniform": True,
+                "mode": "uniform",
                 "seed_points": [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
                 "bbox_min": [-1, -1, -1],
                 "bbox_max": [1, 1, 1]
@@ -61,3 +61,5 @@ async def test_review_generates_uniform_cells(monkeypatch):
     for poly in cells:
         assert len(poly) == 6
         assert np.isfinite(poly).all()
+    # ensure uniform flag propagated from mode
+    assert infill.get("uniform") is True


### PR DESCRIPTION
## Summary
- Translate infill `mode` to legacy `uniform` flag for downstream consumers
- Recognize `mode: "uniform"` during review and generate uniform Voronoi cells
- Test parsing of `mode` and uniform cell generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb4af58b6c8326a3cd9da8e6a7a55c