### PR TITLE
Move model routes into Design API and deprecate Canvas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,29 @@ Implicitus provides a fully implicit pipeline for manufacturing design, enabling
 
 ## Current Capabilities
 
-- **Protobuf Schema & Bindings**  
+- **Protobuf Schema & Bindings**
   Versioned `.proto` definitions for primitives (Box, Sphere, Cylinder) and transforms (Translate, Scale), with auto-generated Rust and Python bindings and JSON interoperability.
 
-- **SDF Evaluation Engine**  
+- **SDF Evaluation Engine**
   High-performance Rust core library to evaluate signed-distance fields for loaded implicit models.
 
-- **AI Adapter Stub**  
+- **AI Adapter Stub**
   Python module to transform text prompts into placeholder implicit models via protobuf messages.
 
-- **Rust Slicer Service**  
+- **Rust Slicer Service**
   Warp-based microservice exposing `POST /slice` to compute layer contours using a marching-squares algorithm, then sorts and closes the loop into ordered contours.
 
-- **Canvas API**  
-  Express.js server providing:
-  - `POST /models` to store implicit models in-memory.  
-  - `GET /models/:id` to retrieve stored models.  
+- **Design API**
+  FastAPI service providing:
+  - `POST /models` to persist implicit models.
+  - `GET /models/:id` to retrieve stored models.
   - `GET /models/:id/slices?layer=<z>&...` to proxy slice requests to the Rust slicer and return JSON contours.
+  - `POST /design` to map natural-language prompts to models.
 
-- **End-to-End Workflow**  
+- **End-to-End Workflow**
   Complete prompt → model storage → slicing pipeline validated via curl and Python scripts.
 
-  ## Current Progress
+## Current Progress
 
 - **LLM-driven specification parsing**: Users can enter natural language prompts which are sent to a local Mistral model. The model returns JSON specs that are parsed into intermediate "draft" specs.
 - **Editable JSON branch workflow**: Draft specs are presented in an editable JSON pane. Users can manually adjust or correct the specification before committing.
@@ -38,12 +39,11 @@ Implicitus provides a fully implicit pipeline for manufacturing design, enabling
   - `POST /design/submit`: Accepts a finalized spec JSON and maps it to the internal Proto, validating it for downstream processing.
 - **Next steps**: Integrate ongoing conversational edits, branch history, and diff-based review workflows.
 
-
 ## Getting Started
 
-**Prerequisites**  
-- Rust ≥ 1.60  
-- Python 3.8+  
+**Prerequisites**
+- Rust ≥ 1.60
+- Python 3.8+
 - Node.js 14+
 
 **Setup & Run**
@@ -54,10 +54,10 @@ cd core_engine
 cargo build
 cargo run --bin slicer_server   # listens on port 4000
 
-# 2) Start the Canvas API
-cd ../canvas_api
-npm install
-node server.js                  # listens on port 3000
+# 2) Start the Design API
+cd ../design_api
+pip install -e .
+uvicorn design_api.main:app --port 8000 --reload
 
 # 3) Run the AI adapter stub (Python)
 cd ../ai_adapter
@@ -68,11 +68,14 @@ print(generate_model("unit sphere"))
 EOF
 
 # 4) Test slicing end-to-end via curl
-curl -X POST http://localhost:3000/models \
+curl -X POST http://localhost:8000/models \
      -H 'Content-Type: application/json' \
      -d '{"id":"test_sphere","root":{"primitive":{"sphere":{"radius":1.0}}}}'
-curl "http://localhost:3000/models/test_sphere/slices?layer=0.0&nx=5&ny=5"
+curl "http://localhost:8000/models/test_sphere/slices?layer=0.0&nx=5&ny=5"
 
 # Or run the Python test script
 cd ../
 python3 test_slice.py
+```
+
+The previous Node-based Canvas API is deprecated; all functionality now lives in the Design API.

--- a/canvas_api/server.js
+++ b/canvas_api/server.js
@@ -6,40 +6,10 @@ const app = express();
 const port = process.env.PORT || 3000;
 const DESIGN_API = process.env.DESIGN_API || 'http://127.0.0.1:5000';
 
-
-// Middleware to parse JSON bodies
 app.use(bodyParser.json());
 
-// In-memory model storage
-const models = new Map();
+console.warn('Canvas API is deprecated. Please use the Design API directly.');
 
-/**
- * Store a new model.
- * Expects a JSON body representing an implicitus.Model with at least an `id` field.
- * Responds with { id: string }.
- */
-app.post('/models', (req, res) => {
-  const model = req.body;
-  if (!model || !model.id) {
-    return res.status(400).json({ error: 'Missing model.id' });
-  }
-  models.set(model.id, model);
-  res.json({ id: model.id });
-});
-
-/**
- * Retrieve a stored model by ID.
- * Responds with the full model JSON or 404 if not found.
- */
-app.get('/models/:id', (req, res) => {
-  const model = models.get(req.params.id);
-  if (!model) {
-    return res.status(404).json({ error: 'Model not found' });
-  }
-  res.json(model);
-});
-
-// Design API endpoint
 app.post('/design', async (req, res) => {
   try {
     const { data } = await axios.post(`${DESIGN_API}/design`, req.body);
@@ -50,53 +20,11 @@ app.post('/design', async (req, res) => {
   }
 });
 
-/**
- * Slice a stored model at a given layer.
- * Query parameters:
- *   - layer (required): z-height for the slice
- *   - x_min, x_max, y_min, y_max, nx, ny (optional): slice bounding box and resolution
- * Returns JSON: { contours: [ [ [x,y], ... ], ... ] }
- */
-app.get('/models/:id/slices', (req, res) => {
-  const model = models.get(req.params.id);
-  if (!model) {
-    return res.status(404).json({ error: 'Model not found' });
-  }
-
-  // Parse slice parameters
-  const z = parseFloat(req.query.layer);
-  if (Number.isNaN(z)) {
-    return res.status(400).json({ error: 'Invalid or missing "layer" parameter' });
-  }
-  // Optional parameters with defaults
-  const x_min = parseFloat(req.query.x_min) || -1.0;
-  const x_max = parseFloat(req.query.x_max) || 1.0;
-  const y_min = parseFloat(req.query.y_min) || -1.0;
-  const y_max = parseFloat(req.query.y_max) || 1.0;
-  const nx = parseInt(req.query.nx) || 50;
-  const ny = parseInt(req.query.ny) || 50;
-
-  // Proxy slice request to Rust slicer service
-  axios.post('http://127.0.0.1:4000/slice', {
-    model,
-    layer: z,
-    x_min,
-    x_max,
-    y_min,
-    y_max,
-    nx,
-    ny
-  })
-  .then(response => {
-    // Forward contours from slicer service
-    res.json(response.data);
-  })
-  .catch(err => {
-    console.error('Slicer service error:', err.message);
-    res.status(500).json({ error: 'Slicing service failure', details: err.message });
-  });
+// All other routes are deprecated
+app.all('*', (_req, res) => {
+  res.status(410).json({ error: 'Canvas API is deprecated. Use the Design API.' });
 });
 
 app.listen(port, () => {
-  console.log(`Implicitus Canvas API listening on port ${port}`);
+  console.log(`Deprecated Canvas API listening on port ${port}`);
 });

--- a/test_slice.py
+++ b/test_slice.py
@@ -9,12 +9,12 @@ model = {
     }
   }
 }
-r = requests.post("http://localhost:3000/models", json=model)
+r = requests.post("http://localhost:8000/models", json=model)
 assert r.ok and r.json().get("id") == "test_sphere"
 
 # 2) slice
 params = {"layer":"0.0", "nx":"5", "ny":"5"}
-r2 = requests.get("http://localhost:3000/models/test_sphere/slices", params=params)
+r2 = requests.get("http://localhost:8000/models/test_sphere/slices", params=params)
 data = r2.json()
 assert "contours" in data and isinstance(data["contours"], list)
 assert len(data["contours"]) > 0, "Expected at least one contour"

--- a/tests/design_api/test_models_api.py
+++ b/tests/design_api/test_models_api.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+import types
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    fake_inference = types.SimpleNamespace(generate=lambda *a, **k: "{}")
+    monkeypatch.setitem(sys.modules, "ai_adapter.inference_pipeline", fake_inference)
+
+    fake_csg = types.SimpleNamespace(
+        review_request=lambda req: ([], "summary"),
+        generate_summary=lambda spec: "summary",
+        update_request=lambda sid, spec, raw: (spec, "summary"),
+    )
+    monkeypatch.setitem(sys.modules, "ai_adapter.csg_adapter", fake_csg)
+
+    fake_mapping = types.SimpleNamespace(map_primitive=lambda spec: spec)
+    monkeypatch.setitem(sys.modules, "design_api.services.mapping", fake_mapping)
+
+    fake_validator = types.SimpleNamespace(validate_model_spec=lambda spec: spec)
+    monkeypatch.setitem(sys.modules, "design_api.services.validator", fake_validator)
+
+    monkeypatch.setenv("MODEL_STORE", str(tmp_path))
+    monkeypatch.setenv("SLICER_URL", "http://slicer")
+
+    app_module = importlib.reload(importlib.import_module("design_api.main"))
+    app_module.design_states.clear()
+    return TestClient(app_module.app)
+
+
+def test_store_and_slice(client, tmp_path, monkeypatch):
+    model = {"id": "test", "root": {"primitive": {"sphere": {"radius": 1.0}}}}
+
+    resp = client.post("/models", json=model)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "test"
+
+    # model persisted
+    assert (tmp_path / "test.json").exists()
+
+    import requests
+    fake_resp = types.SimpleNamespace(json=lambda: {"contours": []}, raise_for_status=lambda: None)
+    monkeypatch.setattr(requests, "post", lambda url, json: fake_resp)
+
+    resp = client.get("/models/test/slices", params={"layer": 0.0})
+    assert resp.status_code == 200
+    assert "contours" in resp.json()


### PR DESCRIPTION
## Summary
- Move model storage and slicing endpoints into the Python Design API with persistent disk-backed storage
- Allow slicer service URL to be configured via `SLICER_URL`
- Deprecate the Node-based Canvas API and update docs and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb76b36804832686bca5d18c59bcb7