### PR TITLE
Add in-memory model registry to Design API

### DIFF
--- a/tests/design_api/test_models.py
+++ b/tests/design_api/test_models.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from design_api.main import app, models
+
+
+def test_store_and_retrieve_model():
+    client = TestClient(app)
+    models.clear()
+    model = {"id": "abc", "name": "test"}
+    resp = client.post("/models", json=model)
+    assert resp.status_code == 200
+    assert resp.json() == {"id": "abc"}
+    resp = client.get("/models/abc")
+    assert resp.status_code == 200
+    assert resp.json() == model
+
+
+def test_get_missing_model_returns_404():
+    client = TestClient(app)
+    models.clear()
+    resp = client.get("/models/missing")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- maintain in-memory model registry for design API
- expose POST /models and GET /models/{id}
- test storing and retrieving models

## Testing
- `pytest tests/design_api/test_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb9a6435d883269b51c74e5994a02f