### PR TITLE
refactor(ui): migrate to design api

### DIFF
--- a/implicitus-ui/tests/voronoi_canvas.visual.spec.ts
+++ b/implicitus-ui/tests/voronoi_canvas.visual.spec.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 let server: ViteDevServer | undefined;
+let serverUrl: string;
 
 test.beforeAll(async () => {
   server = await createServer({
@@ -17,6 +18,7 @@ test.beforeAll(async () => {
     server: { port: 3000, strictPort: true },
   });
   await server.listen();
+  serverUrl = server.resolvedUrls?.local[0] ?? 'http://localhost:3000/';
 });
 
 test.afterAll(async () => {
@@ -38,7 +40,7 @@ test('VoronoiCanvas visual regression', async ({ page }) => {
       env: { NODE_ENV: 'test', VORONOI_ASSERT_Z: 'true' }
     };
   });
-  await page.goto('http://localhost:3000/tests/visual/voronoi_canvas_page.html');
+  await page.goto(`${serverUrl}tests/visual/voronoi_canvas_page.html`);
   const root = page.locator('[data-testid="voronoi-canvas-root"]');
   await expect(root).toHaveAttribute('data-has-flat-edges', 'false');
   const canvas = page.locator('canvas');

--- a/implicitus-ui/vite.config.ts
+++ b/implicitus-ui/vite.config.ts
@@ -1,36 +1,45 @@
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import macros from 'vite-plugin-babel-macros'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
-  babelMacros: {
-    plugins: ['babel-plugin-glsl/macro']
-  },
-  plugins: [
-    macros(),
-    react()
-  ],
-  server: {
-    host: 'localhost',
-    port: 3000,
-    strictPort: true,
-    proxy: {
-      '/design': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        secure: false,
-        configure: (proxy, options) => {
-          // cast to any so TS won’t complain
-          (proxy as any).on('proxyReq', (_proxyReq: ClientRequest, req: IncomingMessage, _res: ServerResponse) => {
-            console.debug('[vite proxy] request to:', req.url);
-          });
-          (proxy as any).on('proxyRes', (proxyRes: IncomingMessage, _req: IncomingMessage, _res: ServerResponse) => {
-            console.debug('[vite proxy] response status:', proxyRes.statusCode);
-          });
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiTarget = env.VITE_API_BASE_URL || 'http://localhost:8000';
+  return {
+    babelMacros: {
+      plugins: ['babel-plugin-glsl/macro']
+    },
+    plugins: [
+      macros(),
+      react()
+    ],
+    server: {
+      host: 'localhost',
+      port: 3000,
+      strictPort: true,
+      proxy: {
+        '/design': {
+          target: apiTarget,
+          changeOrigin: true,
+          secure: false,
+          configure: (proxy, _options) => {
+            // cast to any so TS won’t complain
+            (proxy as any).on('proxyReq', (_proxyReq: ClientRequest, req: IncomingMessage, _res: ServerResponse) => {
+              console.debug('[vite proxy] request to:', req.url);
+            });
+            (proxy as any).on('proxyRes', (proxyRes: IncomingMessage, _req: IncomingMessage, _res: ServerResponse) => {
+              console.debug('[vite proxy] response status:', proxyRes.statusCode);
+            });
+          }
+        },
+        '/models': {
+          target: apiTarget,
+          changeOrigin: true,
+          secure: false,
         }
       }
     }
-  }
-})
+  };
+});


### PR DESCRIPTION
## Summary
- parameterize API base URL and proxy to design API
- update UI endpoints to design API and model slicing routes
- clean up tests to use dynamic dev server URL

## Testing
- `npm test`
- `npm run test:playwright`


------
https://chatgpt.com/codex/tasks/task_e_68bb9c3e2b788326b4e964c902fcc80a