### PR TITLE
Add fixture and negative tests for design API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,22 @@
 # tests/conftest.py
-import os, sys
+import os
+import sys
+
+from fastapi.testclient import TestClient
+import pytest
+
 # add the project root (one level up) onto sys.path
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
+
+from design_api.main import app, models, design_states
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client that resets global state before each test."""
+    models.clear()
+    design_states.clear()
+    return TestClient(app)
+

--- a/tests/design_api/test_models.py
+++ b/tests/design_api/test_models.py
@@ -1,10 +1,7 @@
-from fastapi.testclient import TestClient
-from design_api.main import app, models
+from design_api.main import models
 
 
-def test_store_and_retrieve_model():
-    client = TestClient(app)
-    models.clear()
+def test_store_and_retrieve_model(client):
     model = {"id": "abc", "name": "test"}
     resp = client.post("/models", json=model)
     assert resp.status_code == 200
@@ -14,8 +11,11 @@ def test_store_and_retrieve_model():
     assert resp.json() == model
 
 
-def test_get_missing_model_returns_404():
-    client = TestClient(app)
-    models.clear()
+def test_store_model_missing_id_returns_400(client):
+    resp = client.post("/models", json={"name": "test"})
+    assert resp.status_code == 400
+
+
+def test_get_missing_model_returns_404(client):
     resp = client.get("/models/missing")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add pytest fixture to initialize FastAPI TestClient and clear global state
- extend model, slice, and submission tests with positive and negative scenarios

## Testing
- `pytest tests/design_api/test_models.py tests/design_api/test_slice.py tests/design_api/test_submit_infill.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bba0279d188326a6dbb5ce614a194a