### PR TITLE
feat: compute hex lattice from hexagon vertices

### DIFF
--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -113,15 +113,26 @@ fn hex_sdf(point: (f64, f64, f64), seeds: &[(f64, f64, f64)]) -> f64 {
     best
 }
 
-/// Generate a very simple hex lattice: one vertical edge per seed point.
+/// Generate a hexagonal lattice using explicit cell vertices with vertical
+/// edges suitable for slicing.
+///
+/// Each seed point defines the center of a regular hexagon in the X-Y plane.
+/// For every vertex of that hexagon a vertical edge is emitted, represented by
+/// two vertices at ``z-1`` and ``z+1``.  The returned mesh therefore contains
+/// six vertical struts per seed point.
 pub fn hex_lattice(seeds: &[(f64, f64, f64)]) -> VoronoiMesh {
     let mut vertices = Vec::new();
     let mut edges = Vec::new();
-    for &(x, y, z) in seeds {
-        let base = vertices.len();
-        vertices.push((x, y, z - 1.0));
-        vertices.push((x, y, z + 1.0));
-        edges.push((base, base + 1));
+    for &(cx, cy, cz) in seeds {
+        for i in 0..6 {
+            let angle = std::f64::consts::FRAC_PI_2 + i as f64 * std::f64::consts::PI / 3.0;
+            let x = cx + angle.cos();
+            let y = cy + angle.sin();
+            let base = vertices.len();
+            vertices.push((x, y, cz - 1.0));
+            vertices.push((x, y, cz + 1.0));
+            edges.push((base, base + 1));
+        }
     }
     VoronoiMesh { vertices, edges }
 }

--- a/core_engine/tests/hex_lattice.rs
+++ b/core_engine/tests/hex_lattice.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+use std::sync::Once;
+
+use core_engine::hex_lattice;
+use core_engine::core_engine as pymodule;
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+// Initialize embedded Python with repository path for importing design_api modules
+fn init_python() {
+    static START: Once = Once::new();
+    START.call_once(|| {
+        pyo3::append_to_inittab!(pymodule);
+    });
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let sys = py.import_bound("sys").unwrap();
+        let path = sys.getattr("path").unwrap().downcast::<PyList>().unwrap().clone();
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        path.insert(0, repo_root.to_str().unwrap()).unwrap();
+    });
+}
+
+#[test]
+fn hex_lattice_geometry_matches_reference() {
+    init_python();
+    let seeds = vec![(0.0, 0.0, 0.0)];
+    let mesh = hex_lattice(&seeds);
+    assert_eq!(mesh.vertices.len(), 12);
+    assert_eq!(mesh.edges.len(), 6);
+    let expected_xy = vec![
+        (0.0, 1.0),
+        (-0.8660254037844386, 0.5),
+        (-0.8660254037844387, -0.5),
+        (-1.2246467991473532e-16, -1.0),
+        (0.8660254037844384, -0.5),
+        (0.866025403784439, 0.49999999999999917),
+    ];
+    for (i, (x, y)) in expected_xy.iter().enumerate() {
+        let low = mesh.vertices[2 * i];
+        let high = mesh.vertices[2 * i + 1];
+        assert!((low.0 - x).abs() < 1e-6);
+        assert!((low.1 - y).abs() < 1e-6);
+        assert!((low.2 + 1.0).abs() < 1e-6);
+        assert!((high.0 - x).abs() < 1e-6);
+        assert!((high.1 - y).abs() < 1e-6);
+        assert!((high.2 - 1.0).abs() < 1e-6);
+    }
+    let expected_edges = vec![(0, 1), (2, 3), (4, 5), (6, 7), (8, 9), (10, 11)];
+    assert_eq!(mesh.edges, expected_edges);
+}


### PR DESCRIPTION
## Summary
- model hex lattice as vertical edges at hexagon vertices
- test hex lattice output against expected geometry

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bba869c09c8326828c70299a2d34e9