### PR TITLE
Add bounding box handling to slice configuration

### DIFF
--- a/core_engine/src/slice.rs
+++ b/core_engine/src/slice.rs
@@ -38,6 +38,8 @@ pub struct SliceConfig {
     pub infill_pattern: Option<String>,
     pub wall_thickness: f64,
     pub mode: Option<String>,
+    pub bbox_min: Option<(f64, f64, f64)>,
+    pub bbox_max: Option<(f64, f64, f64)>,
 }
 
 /// Placeholder marching squares edge table: for each case index, list of edge pairs.

--- a/core_engine/tests/box_slice.rs
+++ b/core_engine/tests/box_slice.rs
@@ -36,6 +36,8 @@ async fn slice_box_model_returns_square_contour() {
         y_max: Some(1.5),
         nx: Some(5),
         ny: Some(5),
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let reply = handle_slice(req).await.unwrap();
@@ -82,6 +84,8 @@ async fn slice_returns_debug_for_invalid_model() {
         y_max: None,
         nx: None,
         ny: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let reply = handle_slice(req).await.unwrap();
@@ -112,6 +116,8 @@ async fn slice_returns_debug_for_lattice_primitive() {
         y_max: None,
         nx: None,
         ny: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let reply = handle_slice(req).await.unwrap();

--- a/core_engine/tests/multi_infill_slice.rs
+++ b/core_engine/tests/multi_infill_slice.rs
@@ -30,7 +30,7 @@ fn seeds_from_multiple_blocks_affect_slice() {
         }
     });
 
-    let (seeds, pattern, _, mode) = slicer_server::parse_infill(&model_json);
+    let (seeds, pattern, _, mode, _, _) = slicer_server::parse_infill(&model_json);
     assert_eq!(seeds.len(), 5);
     assert_eq!(pattern.as_deref(), Some("voronoi"));
     assert_eq!(mode.as_deref(), Some("uniform"));
@@ -57,6 +57,8 @@ fn seeds_from_multiple_blocks_affect_slice() {
         infill_pattern: pattern,
         wall_thickness: 0.0,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let result = slice_model(&model, &config);

--- a/core_engine/tests/seed_patterns_slice.rs
+++ b/core_engine/tests/seed_patterns_slice.rs
@@ -42,6 +42,8 @@ fn voronoi_custom_seeds_modify_segments() {
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.0,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let r1 = slice_model(&model, &cfg(seeds_a));
@@ -70,6 +72,8 @@ fn hex_custom_seeds_modify_segments() {
         infill_pattern: Some("hex".into()),
         wall_thickness: 0.0,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let r1 = slice_model(&model, &cfg(seeds_a));

--- a/core_engine/tests/slice_model.rs
+++ b/core_engine/tests/slice_model.rs
@@ -30,6 +30,8 @@ fn slice_model_produces_segments() {
         infill_pattern: None,
         wall_thickness: 0.0,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     // Call the slice and verify it returns non-empty contours and no segments

--- a/core_engine/tests/voronoi_slice.rs
+++ b/core_engine/tests/voronoi_slice.rs
@@ -40,6 +40,8 @@ fn voronoi_infill_slice_matches_expected() {
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.0,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let result = slice_model(&model, &config);

--- a/core_engine/tests/voronoi_uniform_slice.rs
+++ b/core_engine/tests/voronoi_uniform_slice.rs
@@ -86,6 +86,8 @@ fn slice_uniform_voronoi_produces_hex_segments() {
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.0,
         mode: Some("uniform".into()),
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let result = slice_model(&model, &config);

--- a/core_engine/tests/wall_thickness_slice.rs
+++ b/core_engine/tests/wall_thickness_slice.rs
@@ -33,6 +33,8 @@ fn wall_thickness_shifts_contours() {
         infill_pattern: Some("voronoi".into()),
         wall_thickness: 0.5,
         mode: None,
+        bbox_min: None,
+        bbox_max: None,
     };
 
     let thin = slice_model(&model, &config);


### PR DESCRIPTION
## Summary
- extend SliceRequest and SliceConfig with optional bbox_min/bbox_max
- collect bounding-box limits in parse_infill and forward them via handle_slice
- adjust tests for new bounding box configuration

## Testing
- `cargo test --quiet`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbab68f66c83268e7ae8bc1d0278f3