### PR TITLE
Add logging for lattice seed details

### DIFF
--- a/core_engine/src/bin/slicer_server.rs
+++ b/core_engine/src/bin/slicer_server.rs
@@ -356,6 +356,11 @@ pub fn parse_infill(
         &mut bbox_min,
         &mut bbox_max,
     );
+
+    info!(
+        "parse_infill: first_seeds={:?}",
+        seeds.iter().take(3).collect::<Vec<_>>()
+    );
     (
         seeds,
         pattern,

--- a/design_api/main.py
+++ b/design_api/main.py
@@ -184,6 +184,11 @@ async def slice_model(
         return cell_verts, edges
 
     cell_vertices, edge_list = _extract_lattice_data(model)
+    logging.debug(
+        "slice_model: cell_vertices[:3]=%s, edge_list[:3]=%s",
+        cell_vertices[:3] if cell_vertices else None,
+        edge_list[:3] if edge_list else None,
+    )
 
     payload = {
         "model": model,

--- a/design_api/services/infill_service.py
+++ b/design_api/services/infill_service.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 from types import SimpleNamespace
 import numpy as np
 import inspect
+import logging
 
 
 from .voronoi_gen.voronoi_gen import (
@@ -12,6 +13,8 @@ from .voronoi_gen.voronoi_gen import (
     primitive_to_imds_mesh,
 )
 from .seed_utils import resolve_seed_spec
+
+logger = logging.getLogger(__name__)
 
 
 def _edge_list_from_adjacency(adjacency: Any) -> List[List[int]]:
@@ -185,6 +188,12 @@ def generate_hex_lattice(
         primitive,
         **lattice_kwargs,
         **extra_kwargs,
+    )
+
+    logger.debug(
+        "generate_hex_lattice: spacing=%s, seed_pts[:3]=%s",
+        spacing,
+        seed_pts[:3],
     )
 
     debug = {


### PR DESCRIPTION
## Summary
- log spacing and sample seed points when building hex lattices
- record extracted lattice vertices and edges during slicing
- print initial seed points extracted from JSON in the Rust slicer server

## Testing
- `pytest`
- `cargo test --manifest-path core_engine/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68bc520ec9e483268719eb7d5938842f