### PR TITLE
Fix precomputed lattice slice test

### DIFF
--- a/core_engine/tests/precomputed_lattice.rs
+++ b/core_engine/tests/precomputed_lattice.rs
@@ -2,10 +2,11 @@
 mod slicer_server;
 
 use bytes::Bytes;
-use serde_json::json;
+use serde_json::{json, Value};
 use slicer_server::{handle_slice, parse_infill, SliceRequest, SliceResponse};
 use warp::hyper::body::to_bytes;
 use warp::Reply;
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
 
 #[test]
 fn parse_infill_uses_lattice_vertices_as_seeds() {
@@ -25,11 +26,28 @@ fn parse_infill_uses_lattice_vertices_as_seeds() {
 
 #[tokio::test]
 async fn handle_slice_derives_seeds_from_lattice() {
+    // Build a minimal valid model containing a single sphere primitive.
+    let mut model = Model::default();
+    model.id = "precomputed_lattice".into();
+    let sphere = Sphere { radius: 1.0 };
+    let mut prim = Primitive::default();
+    prim.shape = Some(Shape::Sphere(sphere));
+    let mut node = Node::default();
+    node.body = Some(Body::Primitive(prim));
+    model.root = Some(node);
+
+    // Convert the model to JSON and attach an infill pattern so `parse_infill`
+    // picks it up when building the slice configuration.
+    let mut model_json = serde_json::to_value(model).unwrap();
+    if let Value::Object(ref mut obj) = model_json {
+        obj.insert(
+            "modifiers".into(),
+            json!({"infill": {"pattern": "voronoi"}}),
+        );
+    }
+
     let req = SliceRequest {
-        _model: json!({
-            "primitive": {"sphere": {"radius": 1.0}},
-            "modifiers": {"infill": {"pattern": "voronoi"}}
-        }),
+        _model: model_json,
         layer: 0.0,
         x_min: None,
         x_max: None,


### PR DESCRIPTION
## Summary
- build a valid model in the precomputed lattice test so slice requests deserialize correctly

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7602869883269743e68bdc7c7b26