### PR TITLE
Validate slice grid dimensions

### DIFF
--- a/core_engine/tests/precomputed_lattice.rs
+++ b/core_engine/tests/precomputed_lattice.rs
@@ -4,17 +4,14 @@ mod slicer_server;
 use bytes::Bytes;
 
 use serde_json::{json, Value};
-use slicer_server::{handle_slice, parse_infill, SliceRequest, SliceResponse};
+use slicer_server::{handle_slice, SliceRequest, SliceResponse};
 
-use core_engine::implicitus::Model;
-
+use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
 use warp::hyper::body::to_bytes;
 use warp::Reply;
-use core_engine::implicitus::{node::Body, primitive::Shape, Model, Node, Primitive, Sphere};
 
 #[tokio::test]
 async fn handle_slice_derives_seeds_from_lattice() {
-
     // Build a minimal valid model containing a single sphere primitive.
     let mut model = Model::default();
     model.id = "precomputed_lattice".into();
@@ -35,8 +32,10 @@ async fn handle_slice_derives_seeds_from_lattice() {
         );
     }
 
+    let model: Model = serde_json::from_value(model_json).unwrap();
+
     let req = SliceRequest {
-        _model: model_json,
+        _model: model,
         layer: 0.0,
         x_min: None,
         x_max: None,


### PR DESCRIPTION
## Summary
- reject slice requests with fewer than 2 grid steps in X or Y
- cover nx/ny edge cases with tests and fix precomputed lattice test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7bfc00208326b144df204eff8766