### PR TITLE
Allow slice models with extra infill data

### DIFF
--- a/design_api/services/validator.py
+++ b/design_api/services/validator.py
@@ -7,19 +7,30 @@ class ValidationError(Exception):
     """Raised when the JSON spec cannot be parsed into the protobuf schema."""
     pass
 
-def validate_model_spec(spec_dict: dict) -> Model:
+def validate_model_spec(spec_dict: dict, ignore_unknown_fields: bool = False) -> Model:
+    """Validate and convert a raw JSON spec dictionary into a protobuf ``Model``.
+
+    Parameters
+    ----------
+    spec_dict:
+        Dictionary representation of the model.
+    ignore_unknown_fields:
+        When ``True``, unknown keys in ``spec_dict`` will be ignored rather than
+        raising an error. This is useful for round-tripping models that contain
+        auxiliary data (e.g., precomputed lattice fields) which are not part of
+        the core schema.
+
+    Returns
+    -------
+    Model
+        A populated ``implicitus_pb2.Model`` instance.
+
+    Raises
+    ------
+    ValidationError
+        If ``spec_dict`` contains mixed-case keys or fails protobuf parsing.
     """
-    Validate and convert a raw JSON spec dictionary into a protobuf Model.
 
-    Args:
-        spec_dict: A dictionary parsed from LLM JSON output.
-
-    Returns:
-        A populated implicitus_pb2.Model instance.
-
-    Raises:
-        ValidationError: If the JSON does not match the protobuf schema.
-    """
     def _ensure_snake_case(obj):
         if isinstance(obj, dict):
             for k, v in obj.items():
@@ -30,12 +41,35 @@ def validate_model_spec(spec_dict: dict) -> Model:
             for item in obj:
                 _ensure_snake_case(item)
 
+    def _normalize_modifiers(obj):
+        """Convert ``modifiers`` dictionaries into single-item lists.
+
+        Some callers provide a mapping for ``modifiers`` even though the schema
+        defines it as a repeated field. Wrapping these mappings in a list allows
+        ``ParseDict`` to succeed without the caller having to perform the
+        normalization themselves.
+        """
+
+        if isinstance(obj, dict):
+            mods = obj.get("modifiers")
+            if isinstance(mods, dict):
+                obj["modifiers"] = [mods]
+                mods = obj["modifiers"]
+            for v in obj.values():
+                _normalize_modifiers(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _normalize_modifiers(item)
+
+    _normalize_modifiers(spec_dict)
     _ensure_snake_case(spec_dict)
 
     model = Model()
     try:
-        # ParseDict will perform field-level validation
-        ParseDict(spec_dict, model, ignore_unknown_fields=False)
+        # ``ParseDict`` performs field-level validation. We allow callers to
+        # opt-in to ignoring unknown fields so that auxiliary data can be
+        # stripped while preserving the valid portion of the model.
+        ParseDict(spec_dict, model, ignore_unknown_fields=ignore_unknown_fields)
     except (TypeError, DecodeError, ValueError, ParseError) as e:
         raise ValidationError(f"Failed to validate model spec: {e}")
     return model

--- a/tests/design_api/test_validator.py
+++ b/tests/design_api/test_validator.py
@@ -31,3 +31,28 @@ def test_rejects_unknown_keys():
     spec["root"]["unknown_field"] = 123
     with pytest.raises(ValidationError):
         validate_model_spec(spec)
+
+
+def test_ignore_unknown_fields_allows_unknown_keys():
+    spec = map_primitive({"shape": "sphere", "size_mm": 10})
+    spec["root"]["unknown_field"] = 123
+    # Should not raise when ignore_unknown_fields=True
+    msg = validate_model_spec(spec, ignore_unknown_fields=True)
+    assert hasattr(msg, "root")
+
+
+def test_wrapped_modifier_dict():
+    spec = {
+        "root": {
+            "children": [
+                {
+                    "primitive": {"sphere": {"radius": 1.0}},
+                    "modifiers": {"infill": {"pattern": "hex"}},
+                }
+            ]
+        }
+    }
+    msg = validate_model_spec(spec)
+    child = msg.root.children[0]
+    assert len(child.modifiers) == 1
+    assert child.modifiers[0].infill.pattern == "hex"


### PR DESCRIPTION
## Summary
- normalize single modifier mappings into lists before schema validation
- strip seed and lattice arrays from models ahead of slicing
- test validator and slice endpoint with modifier dicts and seed point arrays

## Testing
- `pytest tests/design_api/test_validator.py tests/design_api/test_slice.py tests/design_api/test_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc81ae6eac83268552a4cc61c191f8