### PR TITLE
Standardize session ID handling in design API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # tests/conftest.py
 import os
 import sys
+import types
 
 from fastapi.testclient import TestClient
 import pytest
@@ -9,6 +10,32 @@ import pytest
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
+
+# Provide lightweight stubs for the adapter modules so importing the API
+# does not require building the Rust core engine during tests.
+stub_rust = types.ModuleType("ai_adapter.rust_primitives")
+stub_rust.sample_inside = lambda *args, **kwargs: []
+sys.modules["ai_adapter.rust_primitives"] = stub_rust
+
+stub_adapter = types.ModuleType("ai_adapter.csg_adapter")
+stub_adapter.review_request = lambda *args, **kwargs: ([], "")
+stub_adapter.generate_summary = lambda *args, **kwargs: ""
+stub_adapter.update_request = lambda *args, **kwargs: ([], "")
+sys.modules["ai_adapter.csg_adapter"] = stub_adapter
+
+# Stub out infill generation helpers to avoid heavy dependencies.
+stub_infill = types.ModuleType("design_api.services.infill_service")
+stub_infill.generate_hex_lattice = lambda *args, **kwargs: {}
+stub_infill.generate_voronoi = lambda *args, **kwargs: {}
+sys.modules["design_api.services.infill_service"] = stub_infill
+
+# Minimal stubs for Voronoi helpers used by seed utilities.
+stub_voro_core = types.ModuleType("design_api.services.voronoi_gen.voronoi_gen")
+stub_voro_core.derive_bbox_from_primitive = lambda *args, **kwargs: ([0, 0, 0], [1, 1, 1])
+sys.modules["design_api.services.voronoi_gen.voronoi_gen"] = stub_voro_core
+stub_voro_pkg = types.ModuleType("design_api.services.voronoi_gen")
+stub_voro_pkg.voronoi_gen = stub_voro_core
+sys.modules["design_api.services.voronoi_gen"] = stub_voro_pkg
 
 from design_api.main import app, models, design_states
 

--- a/tests/design_api/test_update_gyroid_infill.py
+++ b/tests/design_api/test_update_gyroid_infill.py
@@ -18,7 +18,8 @@ def test_update_infill_nested_under_modifiers(client, monkeypatch):
 
     resp = client.post(
         "/design/update",
-        json={"sid": sid, "spec": [node], "raw": "add gyroid infill"},
+        params={"sid": sid},
+        json={"spec": [node], "raw": "add gyroid infill"},
     )
     assert resp.status_code == 200
     spec = resp.json()["spec"]


### PR DESCRIPTION
## Summary
- Pass `sid` consistently as a query parameter across `/design/review`, `/design/update`, and `/design/submit`
- Simplify `UpdateRequest` body model and adjust endpoint implementations
- Update tests to match new calling convention and stub heavy dependencies

## Testing
- `pytest tests/design_api/test_update_gyroid_infill.py tests/design_api/test_submit_infill.py tests/design_api/test_seed_debug_patterns.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca77727f083268a0a1e52820ca6c4