### PR TITLE
Handle models without ID in Design API

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -124,7 +124,8 @@ app.add_middleware(
 async def store_model(model: Dict[str, Any]):
     model_id = model.get("id")
     if not model_id:
-        raise HTTPException(status_code=400, detail="Missing model.id")
+        model_id = str(uuid.uuid4())
+        model["id"] = model_id
     models[model_id] = model
     return {"id": model_id}
 

--- a/tests/design_api/test_models.py
+++ b/tests/design_api/test_models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from design_api.main import models
 
 
@@ -11,9 +13,18 @@ def test_store_and_retrieve_model(client):
     assert resp.json() == model
 
 
-def test_store_model_missing_id_returns_400(client):
+def test_store_model_missing_id_generates_uuid(client):
     resp = client.post("/models", json={"name": "test"})
-    assert resp.status_code == 400
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "id" in data
+    generated_id = data["id"]
+    # validate UUID format
+    uuid.UUID(generated_id)
+    # verify model is stored under generated id
+    resp = client.get(f"/models/{generated_id}")
+    assert resp.status_code == 200
+    assert resp.json() == {"id": generated_id, "name": "test"}
 
 
 def test_get_missing_model_returns_404(client):


### PR DESCRIPTION
## Summary
- Generate a UUID when storing a model without an `id`
- Return and store the generated ID
- Test storing models without IDs

## Testing
- `pytest tests/design_api/test_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bca97aacd083268708321e39159620