### PR TITLE
Include default fields in slice model

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -394,6 +394,7 @@ async def slice_model(
     model = MessageToDict(
         proto_model,
         preserving_proto_field_name=True,
+        including_default_value_fields=True,
     )
     logging.debug(
         "slice_model: bbox_min=%s bbox_max=%s cell_vertices[:3]=%s edge_list[:3]=%s cells_len=%s",

--- a/tests/design_api/test_slice_model.py
+++ b/tests/design_api/test_slice_model.py
@@ -101,3 +101,22 @@ def test_slice_generates_lattice_when_missing(client, monkeypatch):
     assert resp.status_code == 200
     assert capture["json"]["cell_vertices"] == [[0, 0, 0]]
     assert capture["json"]["edge_list"] == [[0, 0]]
+
+
+def test_slice_empty_children_round_trip(client, monkeypatch):
+    capture = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: DummyClient(capture))
+    model = {
+        "id": "abc",
+        "version": SPEC_VERSION,
+        "root": {"children": []},
+    }
+    client.post("/models", json=model)
+
+    resp = client.get("/models/abc")
+    assert resp.status_code == 200
+    assert resp.json()["root"]["children"] == []
+
+    resp = client.get("/models/abc/slices?layer=0")
+    assert resp.status_code == 200
+    assert capture["json"]["model"]["root"]["children"] == []


### PR DESCRIPTION
## Summary
- preserve default proto fields when converting slice models to dicts
- test that empty `children` lists round-trip and slice requests succeed

## Testing
- `pytest tests/design_api/test_slice_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b4b23a10832685e8083020618973