### PR TITLE
Handle missing defaults in slice_model and test CORS errors

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -394,8 +394,19 @@ async def slice_model(
     model = MessageToDict(
         proto_model,
         preserving_proto_field_name=True,
-        including_default_value_fields=True,
     )
+
+    def _ensure_children(obj: Any) -> None:
+        """Recursively add missing ``children`` lists to ``obj``."""
+        if isinstance(obj, dict):
+            obj.setdefault("children", [])
+            for child in obj.get("children", []):
+                _ensure_children(child)
+        elif isinstance(obj, list):
+            for item in obj:
+                _ensure_children(item)
+
+    _ensure_children(model.get("root"))
     logging.debug(
         "slice_model: bbox_min=%s bbox_max=%s cell_vertices[:3]=%s edge_list[:3]=%s cells_len=%s",
         bbox_min,

--- a/tests/design_api/test_slice_model.py
+++ b/tests/design_api/test_slice_model.py
@@ -120,3 +120,12 @@ def test_slice_empty_children_round_trip(client, monkeypatch):
     resp = client.get("/models/abc/slices?layer=0")
     assert resp.status_code == 200
     assert capture["json"]["model"]["root"]["children"] == []
+
+
+def test_slice_error_cors_headers(client):
+    resp = client.get(
+        "/models/missing/slices?layer=0",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert resp.status_code == 404
+    assert resp.headers["access-control-allow-origin"] == "http://localhost:3000"


### PR DESCRIPTION
## Summary
- remove unsupported `including_default_value_fields` from `MessageToDict`
- recursively add missing `children` lists after protobuf conversion
- add test confirming CORS headers on slice errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4bac4e1e48326abe751983862c724