### PR TITLE
Ensure default modifiers in slice payloads and mapping

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -397,9 +397,10 @@ async def slice_model(
     )
 
     def _ensure_children(obj: Any) -> None:
-        """Recursively add missing ``children`` lists to ``obj``."""
+        """Recursively add missing ``children`` and ``modifiers`` lists to ``obj``."""
         if isinstance(obj, dict):
             obj.setdefault("children", [])
+            obj.setdefault("modifiers", [])
             for child in obj.get("children", []):
                 _ensure_children(child)
         elif isinstance(obj, list):
@@ -826,7 +827,8 @@ async def submit(req: dict, sid: str = Query(...)):
     proto_dict = {
         'id': str(uuid.uuid4()),
         'root': {
-            'children': children
+            'children': children,
+            'modifiers': [],
         }
     }
     # Validate against protobuf

--- a/design_api/services/mapping.py
+++ b/design_api/services/mapping.py
@@ -38,7 +38,7 @@ def _map_base_shape(spec: dict) -> dict:
     # Ensure leaf nodes include an explicit empty children list for consistency
     return {
         'id': id_str,
-        'root': {'primitive': primitive, 'children': []},
+        'root': {'primitive': primitive, 'children': [], 'modifiers': []},
     }
 
 def map_primitive(node: dict, request_id: str | None = None) -> dict:
@@ -87,8 +87,9 @@ def map_primitive(node: dict, request_id: str | None = None) -> dict:
             "booleanOp": {"union": {}},
             "children": [
                 root,
-                {"primitive": {"shell": shell_params}, "children": []},
+                {"primitive": {"shell": shell_params}, "children": [], "modifiers": []},
             ],
+            "modifiers": [],
         }
 
     # Apply infill modifier (supports Voronoi)
@@ -104,8 +105,9 @@ def map_primitive(node: dict, request_id: str | None = None) -> dict:
             "booleanOp": {"intersection": {}},
             "children": [
                 root,
-                {"primitive": {'lattice': infill_params}, "children": []},
+                {"primitive": {'lattice': infill_params}, "children": [], "modifiers": []},
             ],
+            "modifiers": [],
         }
 
     # Apply boolean_op modifier
@@ -117,9 +119,11 @@ def map_primitive(node: dict, request_id: str | None = None) -> dict:
                 root,
                 map_primitive(bool_params['shape_node'], request_id=request_id),
             ],
+            "modifiers": [],
         }
 
     # Return final wrapped dict with version information
+    root.setdefault('modifiers', [])
     mapped['root'] = root
     # Attach a top-level version so downstream consumers can assert
     # compatibility with the spec format.
@@ -177,7 +181,8 @@ def map_to_proto_dict(spec, request_id: str | None = None):
             "version": 1,
             "root": {
                 "booleanOp": {"union": {}},
-                "children": mapped
+                "children": mapped,
+                "modifiers": [],
             }
         }
     # Log uniform seed points and associated lattice data when present

--- a/tests/design_api/test_slice_model.py
+++ b/tests/design_api/test_slice_model.py
@@ -122,6 +122,27 @@ def test_slice_empty_children_round_trip(client, monkeypatch):
     assert capture["json"]["model"]["root"]["children"] == []
 
 
+def test_slice_sets_empty_modifiers(client, monkeypatch):
+    capture = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: DummyClient(capture))
+    model = {
+        "id": "abc",
+        "version": SPEC_VERSION,
+        "root": {
+            "children": [
+                {"primitive": {"box": {"size": {"x": 1, "y": 1, "z": 1}}}}
+            ]
+        },
+    }
+    client.post("/models", json=model)
+
+    resp = client.get("/models/abc/slices?layer=0")
+    assert resp.status_code == 200
+    root = capture["json"]["model"]["root"]
+    assert root["modifiers"] == []
+    assert root["children"][0]["modifiers"] == []
+
+
 def test_slice_error_cors_headers(client):
     resp = client.get(
         "/models/missing/slices?layer=0",


### PR DESCRIPTION
## Summary
- Default `modifiers` to an empty list when building slice payloads
- Propagate empty `modifiers` lists in mapping utilities for generated nodes
- Add regression test confirming slicer accepts payloads without modifiers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4c51d81d4832691e7c7274cdb6bd3