### PR TITLE
Ensure models include default constraints and modifiers

### DIFF
--- a/design_api/main.py
+++ b/design_api/main.py
@@ -396,6 +396,10 @@ async def slice_model(
         preserving_proto_field_name=True,
     )
 
+    # Ensure top-level lists exist for downstream consumers
+    model.setdefault("constraints", [])
+    model.setdefault("modifiers", [])
+
     def _ensure_modifier(mod: dict) -> None:
         """Ensure modifier dictionaries contain expected list fields."""
 

--- a/design_api/services/mapping.py
+++ b/design_api/services/mapping.py
@@ -59,6 +59,8 @@ def _map_base_shape(spec: dict) -> dict:
     return {
         'id': id_str,
         'root': {'primitive': primitive, 'children': [], 'modifiers': [], 'constraints': []},
+        'constraints': [],
+        'modifiers': [],
     }
 
 def map_primitive(node: dict, request_id: str | None = None) -> dict:
@@ -148,6 +150,8 @@ def map_primitive(node: dict, request_id: str | None = None) -> dict:
     # Attach a top-level version so downstream consumers can assert
     # compatibility with the spec format.
     mapped['version'] = 1
+    mapped.setdefault('constraints', [])
+    mapped.setdefault('modifiers', [])
     logger.debug("map_primitive output mapped", extra={"request_id": request_id, "mapped": mapped})
     return mapped
 
@@ -206,6 +210,8 @@ def map_to_proto_dict(spec, request_id: str | None = None):
             "id": model_id,
             "version": 1,
             "root": root,
+            "constraints": [],
+            "modifiers": [],
         }
     # Log uniform seed points and associated lattice data when present
     infill = spec.get("modifiers", {}).get("infill", {}) if isinstance(spec, dict) else {}
@@ -227,4 +233,6 @@ def map_to_proto_dict(spec, request_id: str | None = None):
 
     # Otherwise it's already a single-node dict
     _ensure_node_lists(mapped.get("root"))
+    mapped.setdefault("constraints", [])
+    mapped.setdefault("modifiers", [])
     return mapped

--- a/tests/design_api/test_slice_model.py
+++ b/tests/design_api/test_slice_model.py
@@ -164,6 +164,22 @@ def test_slice_sets_empty_constraints(client, monkeypatch):
     assert root["children"][0]["constraints"] == []
 
 
+def test_slice_top_level_empty_constraints(client, monkeypatch):
+    capture = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: DummyClient(capture))
+    model = {
+        "id": "abc",
+        "version": SPEC_VERSION,
+        "root": {"children": []},
+        "constraints": [],
+    }
+    client.post("/models", json=model)
+
+    resp = client.get("/models/abc/slices?layer=0")
+    assert resp.status_code == 200
+    assert capture["json"]["model"]["constraints"] == []
+
+
 def test_slice_sets_modifier_constraints(client, monkeypatch):
     capture = {}
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: DummyClient(capture))


### PR DESCRIPTION
## Summary
- Ensure slice model conversions always include empty `constraints` and `modifiers` at the top level
- Propagate default empty lists when mapping or constructing new `Model` dictionaries
- Add regression test ensuring slicer accepts top-level empty `constraints`

## Testing
- `pytest tests/design_api/test_mapping.py -q`
- `pytest tests/design_api/test_slice_model.py::test_slice_top_level_empty_constraints -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59c3513ac83268481eebedd7ecd59