### PR TITLE
Ensure empty repeated fields in specs

### DIFF
--- a/design_api/services/mapping.py
+++ b/design_api/services/mapping.py
@@ -1,7 +1,14 @@
 import uuid
 from ai_adapter.schema.implicitus_pb2 import Primitive
-from ai_adapter.schema.implicitus_pb2 import Modifier, Infill, Shell, BooleanOp, VoronoiLattice
+from ai_adapter.schema.implicitus_pb2 import (
+    Modifier,
+    Infill,
+    Shell,
+    BooleanOp,
+    VoronoiLattice,
+)
 import logging
+from design_api.services.validator import ensure_repeated_fields
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +157,7 @@ def map_primitive(node: dict, request_id: str | None = None) -> dict:
     # compatibility with the spec format.
     mapped['version'] = 1
     mapped.setdefault('constraints', [])
+    ensure_repeated_fields(mapped)
     logger.debug("map_primitive output mapped", extra={"request_id": request_id, "mapped": mapped})
     return mapped
 
@@ -204,13 +212,15 @@ def map_to_proto_dict(spec, request_id: str | None = None):
             "modifiers": [],
         }
         _ensure_node_lists(root)
-        return {
+        res = {
             "id": model_id,
             "version": 1,
             "root": root,
             "constraints": [],
             "modifiers": [],
         }
+        ensure_repeated_fields(res)
+        return res
     # Log uniform seed points and associated lattice data when present
     infill = spec.get("modifiers", {}).get("infill", {}) if isinstance(spec, dict) else {}
     seeds = infill.get("seed_points") or []
@@ -233,4 +243,5 @@ def map_to_proto_dict(spec, request_id: str | None = None):
     _ensure_node_lists(mapped.get("root"))
     mapped.setdefault("constraints", [])
     mapped.setdefault("modifiers", [])
+    ensure_repeated_fields(mapped)
     return mapped

--- a/design_api/services/voronoi_gen/voronoi_gen.py
+++ b/design_api/services/voronoi_gen/voronoi_gen.py
@@ -425,10 +425,10 @@ def build_hex_lattice(
                 verts = cell_data.get("vertices", cell_data)
                 faces = cell_data.get("faces")
                 if faces is None:
-                    faces = [list(range(len(verts)))]
+                    faces = []
                 return {"vertices": verts, "faces": faces}
             verts = cell_data
-            return {"vertices": verts, "faces": [list(range(len(verts)))]}
+            return {"vertices": verts, "faces": []}
 
         if isinstance(cells, dict):
             cells = {k: _attach_faces(v) for k, v in cells.items()}

--- a/tests/design_api/test_repeated_fields.py
+++ b/tests/design_api/test_repeated_fields.py
@@ -1,0 +1,73 @@
+import httpx
+from design_api.services.mapping import map_to_proto_dict
+
+# Reuse simple HTTP client stubs similar to test_slice
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=self)
+
+
+class DummyClient:
+    def __init__(self, capture, status_code=200, data=None):
+        self.capture = capture
+        self.status_code = status_code
+        self.data = {"ok": True} if data is None else data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json):
+        self.capture["url"] = url
+        self.capture["json"] = json
+        return DummyResponse(self.data, self.status_code)
+
+
+def test_mapping_inserts_repeated_fields():
+    spec = {
+        "primitive": {"sphere": {"radius": 1.0}},
+        "modifiers": {
+            "infill": {
+                "pattern": "voronoi",
+                "cells": [{"vertices": [[0, 0, 0]], "faces": [{}]}],
+            },
+            "boolean_op": {"op": "union", "shape_node": {"shape": "sphere", "size_mm": 1}},
+        },
+    }
+    mapped = map_to_proto_dict(spec)
+    lattice = mapped["root"]["children"][0]["children"][1]["primitive"]["lattice"]
+    assert lattice["seed_points"] == []
+    assert lattice["edges"] == []
+    assert lattice["cells"][0]["faces"][0]["vertex_indices"] == []
+    assert mapped["root"]["booleanOp"]["union"]["nodes"] == []
+
+
+def test_slice_preserves_repeated_fields(client, monkeypatch):
+    capture = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: DummyClient(capture))
+    model = {
+        "id": "abc",
+        "version": 1,
+        "root": {
+            "primitive": {"sphere": {"radius": 1.0}},
+            "modifiers": {"infill": {"pattern": "voronoi"}},
+        },
+    }
+    client.post("/models", json=model)
+    resp = client.get("/models/abc/slices?layer=0")
+    assert resp.status_code == 200
+    infill = capture["json"]["model"]["root"]["modifiers"][0]["infill"]
+    assert infill["seed_points"] == []
+    assert infill["edges"] == []
+    assert infill["cells"] == []

--- a/tests/design_api/test_slice_model.py
+++ b/tests/design_api/test_slice_model.py
@@ -43,11 +43,9 @@ def test_slice_defaults_version(client, monkeypatch):
     assert models["abc"]["version"] == SPEC_VERSION
 
 
-def test_slice_incomplete_lattice_returns_400(client, monkeypatch):
+def test_slice_incomplete_lattice_allowed(client, monkeypatch):
     capture = {}
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: DummyClient(capture))
-    # Bypass heavy validation
-    monkeypatch.setattr("design_api.main.validate_proto", lambda m, **k: m)
     model = {
         "id": "abc",
         "version": SPEC_VERSION,
@@ -62,8 +60,8 @@ def test_slice_incomplete_lattice_returns_400(client, monkeypatch):
     }
     client.post("/models", json=model)
     resp = client.get("/models/abc/slices?layer=0")
-    assert resp.status_code == 400
-    assert capture == {}
+    assert resp.status_code == 200
+    assert capture["json"]["model"]["root"]["children"][0]["modifiers"][0]["infill"]["seed_points"] == []
 
 
 def test_slice_generates_lattice_when_missing(client, monkeypatch):


### PR DESCRIPTION
## Summary
- add generic `ensure_repeated_fields` to populate missing repeated protobuf fields
- call helper in mapping and API slicing, and allow slicing with empty lattice data
- guarantee Voronoi cells always include a faces list

## Testing
- `pytest tests/design_api/test_repeated_fields.py::test_mapping_inserts_repeated_fields -q`
- `pytest tests/design_api/test_repeated_fields.py::test_slice_preserves_repeated_fields -q`
- `pytest tests/design_api/test_slice_model.py::test_slice_incomplete_lattice_allowed tests/design_api/test_slice_model.py::test_slice_sets_modifier_constraints tests/design_api/test_repeated_fields.py::test_mapping_inserts_repeated_fields tests/design_api/test_repeated_fields.py::test_slice_preserves_repeated_fields -q`
- `pytest tests/design_api -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5a5440eac83268d398de82c6b9e9f