### PR TITLE
feat(ui): centralize JSON POST requests

### DIFF
--- a/implicitus-ui/src/api.ts
+++ b/implicitus-ui/src/api.ts
@@ -1,0 +1,16 @@
+export async function postJsonWithSid(base: string, path: string, body: any, sid?: string) {
+  const url = new URL(path, base);
+  if (sid) {
+    url.searchParams.set('sid', sid);
+  }
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`HTTP ${response.status} ${response.statusText} - ${text}`);
+  }
+  return await response.json();
+}


### PR DESCRIPTION
## Summary
- add `postJsonWithSid` helper to send JSON requests with optional `sid`
- refactor `App` to use new helper for all POST calls

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ab7b8b848326b476821fe320858d