### PR TITLE
Capture session ID from review response

### DIFF
--- a/implicitus-ui/src/App.tsx
+++ b/implicitus-ui/src/App.tsx
@@ -221,8 +221,11 @@ function App() {
         API_BASE,
         '/design/review',
         { spec: parsed },
-        sessionId || undefined
+        sessionId
       );
+      if (data.sid && !sessionId) {
+        setSessionId(data.sid);
+      }
       setSummary(data.summary || 'Validation successful.');
       setMessages(prev => [...prev, { speaker: 'assistant', text: `Validation: ${data.summary}` }]);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- use `postJsonWithSid` in `handleValidate` and record `sid` from response when starting a session

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5adef78ac8326a8a3589364c1e819